### PR TITLE
Added  AFPanelHeader component

### DIFF
--- a/RichClientDemoTest/src/com/redheap/selenium/components/PanelHeaderTest.java
+++ b/RichClientDemoTest/src/com/redheap/selenium/components/PanelHeaderTest.java
@@ -1,0 +1,42 @@
+package com.redheap.selenium.components;
+
+import com.redheap.selenium.component.AdfPanelHeader;
+import com.redheap.selenium.pages.PanelHeaderDemoPage;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class PanelHeaderTest extends PageTestBase<PanelHeaderDemoPage> {
+
+    @Test
+    public void testParentPanelHeader() {
+        AdfPanelHeader parentPanelHeader = pages.goHome().findParentPanelHeader();
+        assertEquals("Automatic Header", parentPanelHeader.getText());
+        final long expectedHeaderLevel = -1;
+        assertEquals(expectedHeaderLevel, parentPanelHeader.getHeaderLevel());
+    }
+
+    @Test
+    public void testSubPanelHeader() {
+        AdfPanelHeader subPanelHeader = pages.goHome().findSubPanelHeader();
+        assertEquals("Automatic SubHeader", subPanelHeader.getText());
+        //apparently even though we are dealing with a subpanel the headerLevel remains -1.
+        final long expectedHeaderLevel = -1;
+        assertEquals(expectedHeaderLevel, subPanelHeader.getHeaderLevel());
+    }
+
+    public static void main(String[] args) {
+        String[] args2 = { PanelHeaderTest.class.getName() };
+        org.junit.runner.JUnitCore.main(args2);
+    }
+
+    @Override
+    protected Class<PanelHeaderDemoPage> getPageClass() {
+        return PanelHeaderDemoPage.class;
+    }
+
+    @Override
+    protected String getJspxName() {
+        return "panelHeader.jspx";
+    }
+}

--- a/RichClientDemoTest/src/com/redheap/selenium/pages/PanelHeaderDemoPage.java
+++ b/RichClientDemoTest/src/com/redheap/selenium/pages/PanelHeaderDemoPage.java
@@ -1,0 +1,30 @@
+package com.redheap.selenium.pages;
+
+import com.redheap.selenium.component.AdfPanelHeader;
+import com.redheap.selenium.page.Page;
+
+import org.openqa.selenium.WebDriver;
+
+public class PanelHeaderDemoPage extends Page {
+    
+    private final String parentPanelHeader = "dmoTpl:panelHeader";
+    private final String subPanelHeader = "dmoTpl:panelHeader2";
+    
+    public PanelHeaderDemoPage(WebDriver webDriver) {
+        super(webDriver);
+    }
+
+    @Override
+    protected String getExpectedTitle() {
+        return "panelHeader Demo";
+    }
+    
+    public AdfPanelHeader findParentPanelHeader() {
+        return findAdfComponent(parentPanelHeader);
+    }
+    
+    public AdfPanelHeader findSubPanelHeader() {
+        return findAdfComponent(subPanelHeader);
+    }
+
+}

--- a/SeleniumTools/src/com/redheap/selenium/component/AdfPanelHeader.java
+++ b/SeleniumTools/src/com/redheap/selenium/component/AdfPanelHeader.java
@@ -1,0 +1,27 @@
+package com.redheap.selenium.component;
+
+import org.openqa.selenium.WebDriver;
+
+public class AdfPanelHeader extends AdfComponent {
+    
+    public AdfPanelHeader(WebDriver webDriver, String clientid) {
+        super(webDriver, clientid);
+    }
+    
+    /**
+     *
+     * @return The text value of the PanelHeader (the Title)
+     */
+    public String getText(){
+        return (String)getProperty("text");
+    }
+    
+    /**
+     *
+     * @return The header level (H1 through H6 HTML header level)
+     */
+    public long getHeaderLevel(){
+        return (Long)getProperty("headerLevel");
+    }
+    
+}


### PR DESCRIPTION
Includes a Unit test to fetch the title text of the PanelHeader. 
Note that the getHeaderLevel() apparently returns -1 even if we are dealing with a sub panelHeader.
