### PR TITLE
J dev12.2.1.3 selenium 3.3.1+

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,12 @@ $ORACLE_HOME/oracle_common/modules/org.apache.maven_3.2.5/bin/mvn install:instal
     -Dfile=adf-richclient-automation-11.jar -DgroupId=com.oracle.adf \
     -DartifactId=richclient-automation -Dversion=12.2 -Dpackaging=jar
 ```
+
+## Rebuild adf-richclient-automation-11.jar with Selenium 3.3.1 and higher versions
+Unfortunately the richclient-automation library distributed with JDeveloper does not work with Selenium 3.3.1 and higher versions.
+
+See the problems detales in this stackoverlow question [how-to-get-adf-richclient-automation-11-jar-compatible-with-the-latest-selenium](https://stackoverflow.com/questions/52042307/how-to-get-adf-richclient-automation-11-jar-compatible-with-the-latest-selenium).
+
+So for now you need manualy repackage `adf-richclient-automation-11.jar` with Selenium 3.3.1 and higher versions.
+
+This repository [adf-richclient-automation-selenium-3-rebuild](https://github.com/EgorBEremeev/adf-richclient-automation-selenium-3-rebuild) contains Eclipse Java Project and complete instruction to repackage richclient-automation library with preferable version of Selenium libs.

--- a/RichClientDemoTest/RichClientDemoTest-12-2.jpr
+++ b/RichClientDemoTest/RichClientDemoTest-12-2.jpr
@@ -172,7 +172,7 @@
       <hash n="runConfigurationDefinitions">
          <hash n="Default">
             <value n="custom" v="false"/>
-            <value n="javaOptions" v="-Djava.util.logging.config.file=logging.properties -Dphantomjs.binary.path=../libs/phantomjs-1.9.8/phantomjs.exe -Dadf.facesdemo.baseurl=http://localhost:1221/faces-12.2.1.0.0"/>
+            <value n="javaOptions" v="-Djava.util.logging.config.file=logging.properties -Dadf.facesdemo.baseurl=http://127.0.0.1:7101/adf-faces-demo-12.2.1.0.0/"/>
             <value n="name" v="Default"/>
             <url n="runDirectoryURL" path="."/>
             <value n="targetURL"/>
@@ -186,26 +186,16 @@
             <value n="isJDK" v="false"/>
          </hash>
          <hash>
-            <value n="id" v="Adf-richclient-automation-12-2.jar"/>
+            <url n="id" path="../libs/Adf-richclient-automation-lite.library"/>
             <value n="isJDK" v="false"/>
          </hash>
          <hash>
-            <url n="id" path="../libs/Selenium Libs.library"/>
+            <url n="id" path="../libs/Selenium Libs-3-3-1.library"/>
             <value n="isJDK" v="false"/>
          </hash>
       </list>
       <hash n="internalDefinitions">
-         <list n="libraryDefinitions">
-            <hash>
-               <list n="classPath">
-                  <url path="../libs/adf-richclient-automation-12-2.jar" jar-entry=""/>
-               </list>
-               <value n="deployedByDefault" v="true"/>
-               <value n="description" v="Adf-richclient-automation-12-2.jar"/>
-               <value n="id" v="Adf-richclient-automation-12-2.jar"/>
-               <value n="locked" v="true"/>
-            </hash>
-         </list>
+         <list n="libraryDefinitions"/>
       </hash>
       <list n="libraryReferences">
          <hash>
@@ -213,11 +203,11 @@
             <value n="isJDK" v="false"/>
          </hash>
          <hash>
-            <value n="id" v="Adf-richclient-automation-12-2.jar"/>
+            <url n="id" path="../libs/Adf-richclient-automation-lite.library"/>
             <value n="isJDK" v="false"/>
          </hash>
          <hash>
-            <url n="id" path="../libs/Selenium Libs.library"/>
+            <url n="id" path="../libs/Selenium Libs-3-3-1.library"/>
             <value n="isJDK" v="false"/>
          </hash>
       </list>

--- a/RichClientDemoTest/RichClientDemoTest-12-2.jpr
+++ b/RichClientDemoTest/RichClientDemoTest-12-2.jpr
@@ -19,7 +19,7 @@
       <value n="oracle.adfdtinternal.view.rich.binding.migration.JarResourceMigrator" v="11.1.1.1.0"/>
       <value n="oracle.adfdtinternal.view.rich.migration.ComponentIdNodeMigratorHelper" v="11.1.1.1.0.01"/>
       <value n="oracle.adfdtinternal.view.rich.migration.FacesLibraryVersionMigrator" v="11.1.1.1.0.1"/>
-      <value n="oracle.ide.model.Project" v="12.1.3.0.0;12.2.1.0.0"/>
+      <value n="oracle.ide.model.Project" v="12.1.3.0.0;12.2.1.0.0;12.2.1.3.0"/>
       <value n="oracle.ide.model.ResourcePathsMigrator" v="11.1.1.1.0"/>
       <value n="oracle.ideimpl.model.TechnologyScopeUpdateMigrator" v="11.1.2.0.0.5;11.1.2.0.0.6"/>
       <value n="oracle.jbo.dt.jclient.migrator.JCProjectMigrator" v="11.1.1.1.0"/>
@@ -54,6 +54,9 @@
       <value n="oracle.jdevimpl.webservices.WebServicesMigratorHelper" v="11.1.1.1.0"/>
       <value n="oracle.jdevimpl.xml.wl.WeblogicMigratorHelper" v="11.1.1.1.0"/>
       <value n="oracle.modeler.bmmigrate.management.Migration" v="11.1.1.1.0"/>
+      <value n="oracle.sb.tooling.ide.libs.SbProjectMigrator" v="12.1.4.0.0"/>
+      <value n="oracle.tip.tools.ide.fabric.addin.SCAProjectMigrator" v="11.1.1.1.0.13"/>
+      <value n="oracle.tip.tools.ide.workflow.addin.TaskFormMigratorAddin" v="12.1.3.0.0"/>
       <value n="oracle.toplink.workbench.addin.migration.PersistenceProjectMigrator" v="11.1.1.1.0"/>
       <value n="oracle.toplink.workbench.addin.migration.TopLinkProjectMigrator" v="11.1.1.1.0"/>
    </hash>
@@ -67,6 +70,11 @@
       <string v="oracle.bm.commonIde.data.project.ModelerProjectSettings/modelersContentSet"/>
       <string v="oracle.adfdtinternal.model.ide.settings.ADFMSettings/adfmContentSet"/>
       <string v="oracle.toplink.workbench.addin/toplinkContentSet"/>
+      <string v="oracle.tip.tools.ide.fabric.addin.SCAContentSetProvider/sca-content"/>
+      <string v="oracle.sb.tooling.ide.core.projects.SbProjectSettings/sbContentSet"/>
+      <string v="oracle.jdeveloper.model.PathsConfiguration/cepContentSet"/>
+      <string v="oracle.tip.tools.ide.ess.addin.ESSContentSetProvider/ess-content"/>
+      <string v="oracle.bpm.fusion.studio.BPMProjectSettings/bpmProjectsProcessesContentSet"/>
    </list>
    <value n="defaultPackage" v="com.redheap.selenium"/>
    <hash n="oracle.adfdtinternal.model.ide.settings.ADFMSettings">
@@ -182,7 +190,7 @@
             <value n="isJDK" v="false"/>
          </hash>
          <hash>
-            <url n="id" path="../../../../adf-selenium/libs/SeleniumLibs3.0.1.library"/>
+            <url n="id" path="../libs/Selenium Libs.library"/>
             <value n="isJDK" v="false"/>
          </hash>
       </list>
@@ -209,7 +217,7 @@
             <value n="isJDK" v="false"/>
          </hash>
          <hash>
-            <url n="id" path="../../../../adf-selenium/libs/SeleniumLibs3.0.1.library"/>
+            <url n="id" path="../libs/Selenium Libs.library"/>
             <value n="isJDK" v="false"/>
          </hash>
       </list>

--- a/RichClientDemoTest/src/com/redheap/selenium/BotStyleTest.java
+++ b/RichClientDemoTest/src/com/redheap/selenium/BotStyleTest.java
@@ -39,7 +39,7 @@ public class BotStyleTest {
         profile.setPreference("app.update.enabled", false);
         driver = new FirefoxDriver(profile);
 
-        DialogManager.init(driver, TIMEOUT_MSECS);
+        DialogManager.init(driver, TIMEOUT_MSECS,true);
         dialogManager = DialogManager.getInstance();
     }
 
@@ -82,7 +82,7 @@ public class BotStyleTest {
 
         // assert browser and dialog state before we get started
         assertEquals("initially ADF dialogManager should find zero dialogs", 0,
-                     dialogManager.totalNumberOfDialogsOpen());
+                     dialogManager.totalNumberOfDialogsOpen(driver));
         assertNull("initially ADF dialogManager should report no current dialog", dialogManager.getCurrentDialog());
 
         // click button with useWindow="true" and action="dialog:createNewFile"
@@ -92,11 +92,11 @@ public class BotStyleTest {
 
         // verify new dialog is opened and active
         assertEquals("after launching first dialog, ADF dialogManager should find single dialog", 1,
-                     dialogManager.totalNumberOfDialogsOpen());
+                     dialogManager.totalNumberOfDialogsOpen(driver));
         final Dialog firstDialog = dialogManager.getCurrentDialog();
         assertNotNull("after launching first dialog, ADF dialogManager should detect dialog having focus", firstDialog);
         assertEquals("title of dialog should be 'New File'", "New File", firstDialog.getTitle(driver));
-        assertTrue("firstDialog starts out being alive", firstDialog.isAlive());
+        assertTrue("firstDialog starts out being alive", firstDialog.isAlive(driver));
 
         // demonstrate we can also locate new dialog by title and launching component id
         assertEquals("locating dialog by its title should find it", firstDialog,
@@ -108,7 +108,7 @@ public class BotStyleTest {
         // switch back to main window (but keep popup window open)
         dialogManager.selectMainWindow(driver);
         assertEquals("dialog remains running after switching back to main window", 1,
-                     dialogManager.totalNumberOfDialogsOpen());
+                     dialogManager.totalNumberOfDialogsOpen(driver));
         assertNull("dialog no longer reported as current after switching back to main window",
                    dialogManager.getCurrentDialog());
 
@@ -117,7 +117,7 @@ public class BotStyleTest {
         RichWebDrivers.waitForServer(driver, TIMEOUT_MSECS, /*useAutomaticDialogDetection*/true);
 
         // verify new dialog is opened and active
-        assertEquals("two dialogs after clicking button for second time", 2, dialogManager.totalNumberOfDialogsOpen());
+        assertEquals("two dialogs after clicking button for second time", 2, dialogManager.totalNumberOfDialogsOpen(driver));
         Dialog secondDialog = dialogManager.getCurrentDialog();
         assertEquals("second dialog also has 'New File' title", "New File", secondDialog.getTitle(driver));
         assertNotEquals("second dialog has different handle than first dialog", firstDialog, secondDialog);
@@ -127,29 +127,29 @@ public class BotStyleTest {
         // close first dialog (which is not the current dialog).
         // DialogManager also resets active window to main window when detecting closed dialogs
         firstDialog.close(driver); // includes RichWebDrivers.waitForServer(..,..,true)
-        assertEquals("one dialog remaining after closing first dialog", 1, dialogManager.totalNumberOfDialogsOpen());
+        assertEquals("one dialog remaining after closing first dialog", 1, dialogManager.totalNumberOfDialogsOpen(driver));
         assertEquals("main browser window active after closing first dialog", null, dialogManager.getCurrentDialog());
-        assertFalse("first dialog handle should be marked dead", firstDialog.isAlive());
+        assertFalse("first dialog handle should be marked dead", firstDialog.isAlive(driver));
 
         // make second dialog current and show we can close current dialog
         secondDialog.focus(driver);
         assertEquals("second dialog window active after switching to it", secondDialog,
                      dialogManager.getCurrentDialog());
         secondDialog.close(driver); // includes RichWebDrivers.waitForServer(..,..,true)
-        assertEquals("no dialogs open after closing second dialog", 0, dialogManager.totalNumberOfDialogsOpen());
+        assertEquals("no dialogs open after closing second dialog", 0, dialogManager.totalNumberOfDialogsOpen(driver));
         assertNull("main browser window active after closing second dialog", dialogManager.getCurrentDialog());
-        assertFalse("first dialog handle still marked dead after closing second dialog", firstDialog.isAlive());
-        assertFalse("second dialog handle marked dead after closing", secondDialog.isAlive());
+        assertFalse("first dialog handle still marked dead after closing second dialog", firstDialog.isAlive(driver));
+        assertFalse("second dialog handle marked dead after closing", secondDialog.isAlive(driver));
 
         // click button once more to open new popup, but this time close with save button in popup
         launchDialogButton.click();
         RichWebDrivers.waitForServer(driver, TIMEOUT_MSECS, /*useAutomaticDialogDetection*/true);
-        assertEquals("one dialog running for final test", 1, dialogManager.totalNumberOfDialogsOpen());
+        assertEquals("one dialog running for final test", 1, dialogManager.totalNumberOfDialogsOpen(driver));
         assertNotNull("dialog active after launching for final test", dialogManager.getCurrentDialog());
         driver.findElement(ByRich.locator("rich=saveNewFile")).click();
         RichWebDrivers.waitForServer(driver, TIMEOUT_MSECS, /*useAutomaticDialogDetection*/true);
         assertEquals("no dialogs running after pressing Save button in dialog", 0,
-                     dialogManager.totalNumberOfDialogsOpen());
+                     dialogManager.totalNumberOfDialogsOpen(driver));
         assertNull("main browser window active afer pressing Save button in dialog", dialogManager.getCurrentDialog());
     }
 

--- a/RichClientDemoTest/src/com/redheap/selenium/components/ButtonTest.java
+++ b/RichClientDemoTest/src/com/redheap/selenium/components/ButtonTest.java
@@ -82,21 +82,21 @@ public class ButtonTest extends PageTestBase<ButtonDemoPage> {
         ButtonDemoPage page = pages.goHome();
 
         DialogManager dialogManager = driver.getDialogManager();
-        assertEquals(0, dialogManager.totalNumberOfDialogsOpen());
+        assertEquals(0, dialogManager.totalNumberOfDialogsOpen(webdriver));
         assertNull(dialogManager.getCurrentDialog());
 
         // find an click af:button with useWindow='true'
         NewFileWindowDialog dialog = page.clickUseWindowButton(); // opens popup in new browser window
 
         // verify new dialog is opened and active
-        assertEquals(1, dialogManager.totalNumberOfDialogsOpen());
+        assertEquals(1, dialogManager.totalNumberOfDialogsOpen(webdriver));
         Dialog firstDialog = dialogManager.getCurrentDialog();
         assertNotNull(firstDialog);
         assertEquals("New File", firstDialog.getTitle(webdriver));
 
         // close dialog by clicking Save button in dialog
         dialog.findSaveButton().clickWithDialogDetect();
-        assertEquals(0, dialogManager.totalNumberOfDialogsOpen());
+        assertEquals(0, dialogManager.totalNumberOfDialogsOpen(webdriver));
     }
 
     @Test
@@ -105,14 +105,14 @@ public class ButtonTest extends PageTestBase<ButtonDemoPage> {
         ButtonDemoPage page = pages.goHome();
 
         DialogManager dialogManager = driver.getDialogManager();
-        assertEquals(0, dialogManager.totalNumberOfDialogsOpen());
+        assertEquals(0, dialogManager.totalNumberOfDialogsOpen(webdriver));
         assertNull(dialogManager.getCurrentDialog());
 
         // find an click af:button with useWindow='true'
         NewFileWindowDialog dialog = page.clickUseWindowInlineDocButton(); // opens popup in inline popup with iframe
 
         // verify new dialog is opened and active
-        assertEquals(1, dialogManager.totalNumberOfDialogsOpen());
+        assertEquals(1, dialogManager.totalNumberOfDialogsOpen(webdriver));
         Dialog firstDialog = dialogManager.getCurrentDialog();
         assertNotNull(firstDialog);
         assertEquals("New File", firstDialog.getTitle(webdriver));
@@ -120,7 +120,7 @@ public class ButtonTest extends PageTestBase<ButtonDemoPage> {
         // close dialog programatically (Save & Cancel buttons will throw error)
         assertFalse(dialog.findSaveButton().isDisabled());
         dialog.close();
-        assertEquals(0, dialogManager.totalNumberOfDialogsOpen());
+        assertEquals(0, dialogManager.totalNumberOfDialogsOpen(webdriver));
     }
 
     @Test
@@ -129,7 +129,7 @@ public class ButtonTest extends PageTestBase<ButtonDemoPage> {
         ButtonDemoPage page = pages.goHome();
 
         DialogManager dialogManager = driver.getDialogManager();
-        assertEquals(0, dialogManager.totalNumberOfDialogsOpen());
+        assertEquals(0, dialogManager.totalNumberOfDialogsOpen(webdriver));
         assertNull(dialogManager.getCurrentDialog());
 
         String mainwindow = webdriver.getWindowHandle();

--- a/RichClientDemoTest/src/com/redheap/selenium/components/DeclarativeComponentTest.java
+++ b/RichClientDemoTest/src/com/redheap/selenium/components/DeclarativeComponentTest.java
@@ -1,0 +1,57 @@
+package com.redheap.selenium.components;
+
+import com.redheap.selenium.component.AdfDynamicDeclarativeComponent;
+import com.redheap.selenium.component.AdfInputListOfValues;
+import com.redheap.selenium.component.AdfInputText;
+import com.redheap.selenium.component.AdfQuery;
+import com.redheap.selenium.fragments.DynamicDeclarativeComponentExampleFragment;
+import com.redheap.selenium.pages.DeclarativeComponentDemoPage;
+import com.redheap.selenium.pages.InputListOfValuesDemoPage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+
+public class DeclarativeComponentTest extends PageTestBase<DeclarativeComponentDemoPage> {
+
+    @Test
+    public void testInteractionWithDeclarativeComponent() {
+        DeclarativeComponentDemoPage dcdPage = pages.goHome();
+        dcdPage.find_it1().typeValue("testInteractionWithDeclarativeComponent");
+        dcdPage.find_nameTypeChoice().clickItemByIndex(1);
+        dcdPage.find_attributeUpdateButton().click();
+
+        DynamicDeclarativeComponentExampleFragment lwdcFragment = dcdPage.get_lwdcDeclarativeComponentContent();
+
+        assertEquals("Test value does not pass into Declarative Component", "testInteractionWithDeclarativeComponent",
+                     lwdcFragment.find_lwdcInputText().getContent());
+        assertEquals("Array item value does not pass to Declarative Component", "Item A",
+                     lwdcFragment.find_itemsText(0).getContent());
+
+
+    }
+
+
+    public static void main(String[] args) {
+        String[] args2 = { DeclarativeComponentTest.class.getName() };
+        org.junit
+           .runner
+           .JUnitCore
+           .main(args2);
+    }
+
+    @Override
+    protected Class<DeclarativeComponentDemoPage> getPageClass() {
+        return DeclarativeComponentDemoPage.class;
+    }
+
+    @Override
+    protected String getJspxName() {
+        return "declarativeComponent.jspx";
+    }
+}

--- a/RichClientDemoTest/src/com/redheap/selenium/components/DvtSchedulingGanttTest.java
+++ b/RichClientDemoTest/src/com/redheap/selenium/components/DvtSchedulingGanttTest.java
@@ -1,0 +1,63 @@
+package com.redheap.selenium.components;
+
+import com.redheap.selenium.component.AdfTable;
+import com.redheap.selenium.component.AdfTreeTable;
+import com.redheap.selenium.component.DvtSchedulingGantt;
+import com.redheap.selenium.component.RowInfo;
+import com.redheap.selenium.pages.DvtSchedulingGanttDemoPage;
+import com.redheap.selenium.pages.TableDetailStampDemoPage;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+import org.openqa.selenium.interactions.Actions;
+
+
+public class DvtSchedulingGanttTest extends PageTestBase<DvtSchedulingGanttDemoPage> {
+
+    /**Test interractions with sub-components of Scheduling Gantt.
+     *  - context menus
+     *  - customer list (DataTreeTable)
+     *  - tasks (ChartTreeTable, taskbar)
+     */
+    @Test
+    public void testGantt () {
+        
+        DvtSchedulingGantt gantt = pages.goHome().find_schedulingGant();
+        AdfTreeTable dtt=gantt.findDataTreeTable(); // customer list
+        AdfTreeTable ctt=gantt.findChartTreeTable(); // tasks chart
+        
+        //customer row and columns
+        dtt.findAdfComponent(DvtSchedulingGanttDemoPage.getdepartmentOutputTextId(), 2).getElement().getText();
+        dtt.findAdfComponent(DvtSchedulingGanttDemoPage.getdepartmentOutputTextId(), 2).contextClick();
+        
+        //experimental. maybe it is possible to use 
+//        RowInfo cttRowInfo = ctt.getRowInfo("0");
+//        new Actions(driver.getDriver()).contextClick(cttRowInfo.getBlock()).perform();    //падает внутри webdriver
+        
+        //tasks and task's context menu
+        //gantt.findTaskBarElement(0, "5731921");
+        gantt.taskbarContextClick(0, "t11");
+        gantt.taskbarSelect(1, "t21");
+
+    }
+
+
+    public static void main(String[] args) {
+        String[] args2 = { DvtSchedulingGanttTest.class.getName() };
+        org.junit.runner.JUnitCore.main(args2);
+    }
+
+    @Override
+    protected Class<DvtSchedulingGanttDemoPage> getPageClass() {
+        return DvtSchedulingGanttDemoPage.class;
+    }
+
+    @Override
+    protected String getJspxName() {
+        return "schedulingGantt.jspx";
+    }
+}

--- a/RichClientDemoTest/src/com/redheap/selenium/components/DynamicDeclarativeComponentTest.java
+++ b/RichClientDemoTest/src/com/redheap/selenium/components/DynamicDeclarativeComponentTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 
-public class DeclarativeComponentTest extends PageTestBase<DeclarativeComponentDemoPage> {
+public class DynamicDeclarativeComponentTest extends PageTestBase<DeclarativeComponentDemoPage> {
 
     @Test
     public void testInteractionWithDeclarativeComponent() {
@@ -38,7 +38,7 @@ public class DeclarativeComponentTest extends PageTestBase<DeclarativeComponentD
 
 
     public static void main(String[] args) {
-        String[] args2 = { DeclarativeComponentTest.class.getName() };
+        String[] args2 = { DynamicDeclarativeComponentTest.class.getName() };
         org.junit
            .runner
            .JUnitCore

--- a/RichClientDemoTest/src/com/redheap/selenium/components/InputComboboxListOfValuesTest.java
+++ b/RichClientDemoTest/src/com/redheap/selenium/components/InputComboboxListOfValuesTest.java
@@ -1,37 +1,20 @@
 package com.redheap.selenium.components;
 
 import com.redheap.selenium.component.AdfInputComboboxListOfValues;
-import com.redheap.selenium.component.AdfInputText;
-import com.redheap.selenium.component.AdfQuery;
 import com.redheap.selenium.component.AdfTable;
-import com.redheap.selenium.component.AdfTreeTable;
-import com.redheap.selenium.component.DvtSchedulingGantt;
-import com.redheap.selenium.component.RowInfo;
-import com.redheap.selenium.pages.DvtSchedulingGanttDemoPage;
 import com.redheap.selenium.pages.InputComboboxListOfValuesDemoPage;
-import com.redheap.selenium.pages.TableDetailStampDemoPage;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-
 import java.util.List;
 
-import static org.junit.Assert.*;
-import static org.junit.Assert.*;
-import static org.junit.Assert.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
-
-import org.openqa.selenium.interactions.Actions;
 
 
 public class InputComboboxListOfValuesTest extends PageTestBase<InputComboboxListOfValuesDemoPage> {
 
-    /**Test interractions with sub-components of Scheduling Gantt.
-     *  - context menus
-     *  - customer list (DataTreeTable)
-     *  - tasks (ChartTreeTable, taskbar)
-     */
     @Test
     public void testDropdownTable () {
         //Here are typical tests for dropdown list
@@ -57,50 +40,6 @@ public class InputComboboxListOfValuesTest extends PageTestBase<InputComboboxLis
         assertEquals("Selected value does not match to expected for row with index 0", "Bejond6", enameCombo.getContent());
 
         assertFalse("Ename combobox is not available for typing value", enameCombo.isDisabled());
-        
-        /*
-        //Пример работы с элементами автоматически генерируемого popup'а поиска для компонента AdfInputListofValues
-        //Открываем окно поиска и проверяем, что оно отобразилось
-        p6FragmenteEnterData.findPartySiteNumber().clickSearchIcon();
-        assertTrue("Serch Party Popup не открылся", p6FragmenteEnterData.findPartySiteNumber().isPopupVisible());
-        //Далее получить внутренний компонент AdfQuery
-        AdfQuery partySitePopupQuery = p6FragmenteEnterData.findPartySiteNumber().findLovDialogQuery();
-        //И далее получить поля для критериев поиска и вести в поля значения
-        AdfInputText partySiteNameCriterion = partySitePopupQuery.<AdfInputText>findCriterionValueFieldByIndex(0, 0);
-        AdfInputText partySiteInnCriterion = partySitePopupQuery.<AdfInputText>findCriterionValueFieldByIndex(1, 0);
-        AdfInputText partySiteNumberCriterion = partySitePopupQuery.<AdfInputText>findCriterionValueFieldByIndex(2, 0);
-
-        partySiteNameCriterion.typeValue("");
-        partySiteInnCriterion.typeValue("");
-        partySiteNumberCriterion.typeValue("3");
-
-
-        //Либо более краткий вариант
-        partySitePopupQuery.<AdfInputText>findCriterionValueFieldByIndex(2, 0).typeValue("4");
-        //Далее инициировать поиск
-        p6FragmenteEnterData.findPartySiteNumber()
-                            .findLovDialogQuery()
-                            .clickPopupQuerySearchButton();
-
-        //Далее проверить что результа поиска не пустой
-        assertFalse("Поиск ничего не вернул", p6FragmenteEnterData.findPartySiteNumber()
-                                                                  .findLovDialogTable()
-                                                                  .isEmpty());
-        //Тест требования на максимальный объем выборки в 50 записей
-        long searchResultRowNumber = p6FragmenteEnterData.findPartySiteNumber()
-                                                         .findLovDialogTable()
-                                                         .getRowCount();
-        assertTrue("Записей более 50", searchResultRowNumber <= 50);
-
-        //Если две проверки выше успешны, то выбрать первую строку из результатов поиска
-        p6FragmenteEnterData.findPartySiteNumber()
-                            .findLovDialogTable()
-                            .selectRow(0);
-        p6FragmenteEnterData.findPartySiteNumber()
-                            .findSearchDialog()
-                            .findOkButton()
-                            .click(); */
-
     }
 
 

--- a/RichClientDemoTest/src/com/redheap/selenium/components/InputComboboxListOfValuesTest.java
+++ b/RichClientDemoTest/src/com/redheap/selenium/components/InputComboboxListOfValuesTest.java
@@ -1,0 +1,121 @@
+package com.redheap.selenium.components;
+
+import com.redheap.selenium.component.AdfInputComboboxListOfValues;
+import com.redheap.selenium.component.AdfInputText;
+import com.redheap.selenium.component.AdfQuery;
+import com.redheap.selenium.component.AdfTable;
+import com.redheap.selenium.component.AdfTreeTable;
+import com.redheap.selenium.component.DvtSchedulingGantt;
+import com.redheap.selenium.component.RowInfo;
+import com.redheap.selenium.pages.DvtSchedulingGanttDemoPage;
+import com.redheap.selenium.pages.InputComboboxListOfValuesDemoPage;
+import com.redheap.selenium.pages.TableDetailStampDemoPage;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.*;
+import static org.junit.Assert.*;
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+import org.openqa.selenium.interactions.Actions;
+
+
+public class InputComboboxListOfValuesTest extends PageTestBase<InputComboboxListOfValuesDemoPage> {
+
+    /**Test interractions with sub-components of Scheduling Gantt.
+     *  - context menus
+     *  - customer list (DataTreeTable)
+     *  - tasks (ChartTreeTable, taskbar)
+     */
+    @Test
+    public void testDropdownTable () {
+        //Here are typical tests for dropdown list
+        
+        AdfInputComboboxListOfValues enameCombo = pages.goHome().find_idInputComboboxListOfValues();
+        
+        //Disclose dropdown list
+        enameCombo.clickDropdownIcon();
+        AdfTable enameDropdownTable = enameCombo.findDropdownTable();
+        assertNotNull("Dropdown List Of Values does not shown or empty", enameDropdownTable);
+
+        // Getting rows in dropdown displayed on the client side. This means without any additional fetching from the server side.
+        // Having list you can implement assert according to the way you store your test data
+        // Also note that you can easily add step for scrolling the dropdownlist and assert the next fetched rows
+        List<String> enameClientSideDropdownTableRows = new ArrayList<String>();
+        enameClientSideDropdownTableRows = enameCombo.getClientSideDropdownTableRows();
+
+        //Either you can just test that dropdown LOV is not empty or it is :)
+        //Just mention which count do you want to test: client side -> getClientRowCount() or server side -> getRowCount()
+ 
+        Long orgNameDisclosedRowsCount = enameDropdownTable.getClientRowCount();
+        enameDropdownTable.selectRow(0);
+        assertEquals("Selected value does not match to expected for row with index 0", "Bejond6", enameCombo.getContent());
+
+        assertFalse("Ename combobox is not available for typing value", enameCombo.isDisabled());
+        
+        /*
+        //Пример работы с элементами автоматически генерируемого popup'а поиска для компонента AdfInputListofValues
+        //Открываем окно поиска и проверяем, что оно отобразилось
+        p6FragmenteEnterData.findPartySiteNumber().clickSearchIcon();
+        assertTrue("Serch Party Popup не открылся", p6FragmenteEnterData.findPartySiteNumber().isPopupVisible());
+        //Далее получить внутренний компонент AdfQuery
+        AdfQuery partySitePopupQuery = p6FragmenteEnterData.findPartySiteNumber().findLovDialogQuery();
+        //И далее получить поля для критериев поиска и вести в поля значения
+        AdfInputText partySiteNameCriterion = partySitePopupQuery.<AdfInputText>findCriterionValueFieldByIndex(0, 0);
+        AdfInputText partySiteInnCriterion = partySitePopupQuery.<AdfInputText>findCriterionValueFieldByIndex(1, 0);
+        AdfInputText partySiteNumberCriterion = partySitePopupQuery.<AdfInputText>findCriterionValueFieldByIndex(2, 0);
+
+        partySiteNameCriterion.typeValue("");
+        partySiteInnCriterion.typeValue("");
+        partySiteNumberCriterion.typeValue("3");
+
+
+        //Либо более краткий вариант
+        partySitePopupQuery.<AdfInputText>findCriterionValueFieldByIndex(2, 0).typeValue("4");
+        //Далее инициировать поиск
+        p6FragmenteEnterData.findPartySiteNumber()
+                            .findLovDialogQuery()
+                            .clickPopupQuerySearchButton();
+
+        //Далее проверить что результа поиска не пустой
+        assertFalse("Поиск ничего не вернул", p6FragmenteEnterData.findPartySiteNumber()
+                                                                  .findLovDialogTable()
+                                                                  .isEmpty());
+        //Тест требования на максимальный объем выборки в 50 записей
+        long searchResultRowNumber = p6FragmenteEnterData.findPartySiteNumber()
+                                                         .findLovDialogTable()
+                                                         .getRowCount();
+        assertTrue("Записей более 50", searchResultRowNumber <= 50);
+
+        //Если две проверки выше успешны, то выбрать первую строку из результатов поиска
+        p6FragmenteEnterData.findPartySiteNumber()
+                            .findLovDialogTable()
+                            .selectRow(0);
+        p6FragmenteEnterData.findPartySiteNumber()
+                            .findSearchDialog()
+                            .findOkButton()
+                            .click(); */
+
+    }
+
+
+    public static void main(String[] args) {
+        String[] args2 = { InputComboboxListOfValuesTest.class.getName() };
+        org.junit.runner.JUnitCore.main(args2);
+    }
+
+    @Override
+    protected Class<InputComboboxListOfValuesDemoPage> getPageClass() {
+        return InputComboboxListOfValuesDemoPage.class;
+    }
+
+    @Override
+    protected String getJspxName() {
+        return "inputComboboxListOfValues.jspx";
+    }
+}

--- a/RichClientDemoTest/src/com/redheap/selenium/components/InputListOfValuesTest.java
+++ b/RichClientDemoTest/src/com/redheap/selenium/components/InputListOfValuesTest.java
@@ -1,0 +1,78 @@
+package com.redheap.selenium.components;
+
+import com.redheap.selenium.component.AdfInputListOfValues;
+import com.redheap.selenium.component.AdfInputText;
+import com.redheap.selenium.component.AdfQuery;
+import com.redheap.selenium.pages.InputListOfValuesDemoPage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+
+public class InputListOfValuesTest extends PageTestBase<InputListOfValuesDemoPage> {
+
+    @Test
+    public void testInputListofValuesDefaultSearchPopup() {
+        AdfInputListOfValues enameLOV = pages.goHome().findEname();
+        
+        //Examples how to interract with default search popup of AdfInputListofValues component and general tests
+        //Open seacrh popup and test that it is displayed
+        enameLOV.clickSearchIcon();
+        assertTrue("Serch Party Popup не открылся", enameLOV.isPopupVisible());
+        //Then getting an internal component AdfQuery
+        AdfQuery enamePopupQuery = enameLOV.findLovDialogQuery();
+        //И далее получить поля для критериев поиска и вести в поля значения
+        //And then getting search criteria fields and type values into them.
+            //See also comment for findCriterionValueFieldByIndex() method
+        AdfInputText enameEnameCriterion = enamePopupQuery.<AdfInputText>findCriterionValueFieldByIndex(0, 0);
+
+        enameEnameCriterion.typeValue("");
+
+        //Also the short variant works perfectly
+        enamePopupQuery.<AdfInputText>findCriterionValueFieldByIndex(0, 0).typeValue("A");
+        //Then init searching
+        enameLOV.findLovDialogQuery().clickPopupQuerySearchButton();
+
+        //Then we could test that result is not empty or it is 
+        assertFalse("Search result is empty", enameLOV.findLovDialogTable().isEmpty());
+        //As well the max number of resulted rows could be tested
+        long searchResultRowNumber = enameLOV.findLovDialogTable().getRowCount();
+        assertTrue("Search result contains more then 150 rows", searchResultRowNumber <= 150);
+
+        //If tests for result set is passed then we can select row and finish with search popup
+        enameLOV.findLovDialogTable().selectRow(0);
+        enameLOV.findSearchDialog()
+                .findOkButton()
+                .click();
+
+        //Then we can test assigning fields of selected row on popup to inputText components of the page
+        assertEquals("Value assign incorrectly", "0", pages.goHome().findEmpno().getContent());
+        assertEquals("Value assign incorrectly", "10", pages.goHome().findDeptno().getContent());
+        assertEquals("Value assign incorrectly", "1/19/1998", pages.goHome().findHireDate().getContent());
+        assertEquals("Value assign incorrectly", "1", pages.goHome().findManager().getContent());
+        assertEquals("Value assign incorrectly", "23232", pages.goHome().findSalary().getContent());
+        assertEquals("Value assign incorrectly", "66767", pages.goHome().findCommision().getContent());
+
+    }
+
+
+    public static void main(String[] args) {
+        String[] args2 = { InputListOfValuesTest.class.getName() };
+        org.junit
+           .runner
+           .JUnitCore
+           .main(args2);
+    }
+
+    @Override
+    protected Class<InputListOfValuesDemoPage> getPageClass() {
+        return InputListOfValuesDemoPage.class;
+    }
+
+    @Override
+    protected String getJspxName() {
+        return "inputListOfValues.jspx";
+    }
+}

--- a/RichClientDemoTest/src/com/redheap/selenium/components/SelectBooleanRadioTest.java
+++ b/RichClientDemoTest/src/com/redheap/selenium/components/SelectBooleanRadioTest.java
@@ -39,7 +39,7 @@ public class SelectBooleanRadioTest extends PageTestBase<SelectBooleanRadioDemoP
         assertTrue(Boolean.FALSE.equals(radio.getValue()));
         radio.click();
         assertTrue(Boolean.TRUE.equals(radio.getValue()));
-        radio.findGroupItems().get(3).click();
+        radio.findGroupItems().get(radio.findGroupItems().size()-1).click();
         assertTrue(Boolean.FALSE.equals(radio.getValue()));
     }
 

--- a/RichClientDemoTest/src/com/redheap/selenium/components/TableTest.java
+++ b/RichClientDemoTest/src/com/redheap/selenium/components/TableTest.java
@@ -66,6 +66,14 @@ public class TableTest extends PageTestBase<TableDetailStampDemoPage> {
         TableDetailStampDemoPage page = pages.goHome();
         assertEquals(5400, page.findTable().getRowCount());
     }
+    
+    @Test
+    public void testSelectRowByColumnCellValue() {
+        TableDetailStampDemoPage page = pages.goHome();
+        AdfTable table = page.findTable();
+        table.selectRow("dmoTpl:table1:c7", "admin.jar");
+        table.selectRow("dmoTpl:table1:c7", "connectors");
+    }
 
     public static void main(String[] args) {
         String[] args2 = { TableTest.class.getName() };

--- a/RichClientDemoTest/src/com/redheap/selenium/fragments/DynamicDeclarativeComponentExampleFragment.java
+++ b/RichClientDemoTest/src/com/redheap/selenium/fragments/DynamicDeclarativeComponentExampleFragment.java
@@ -1,0 +1,93 @@
+package com.redheap.selenium.fragments;
+
+import com.redheap.selenium.component.AdfDynamicDeclarativeComponent;
+import com.redheap.selenium.component.AdfInputText;
+import com.redheap.selenium.component.AdfOutputText;
+import com.redheap.selenium.page.DeclarativeComponentFragment;
+
+public class DynamicDeclarativeComponentExampleFragment extends DeclarativeComponentFragment {
+    
+    public DynamicDeclarativeComponentExampleFragment(AdfDynamicDeclarativeComponent dclr) {
+        super(dclr);
+    }
+    
+    /*
+     * XSLT Generated 
+     * This is Page Object Model for the tested ADF Page.
+     * The model includes java code for those of Adf Faces Tag which are listed xsl:template match=. You can change this list according to your needs and re-generate code for this class.
+     * Generated code includes: 
+     *      - String constant with ADF component AbsoluteId value. This constant then is used to locate component by corresponding findAdfComponent() method of SeleniumTools library.
+     *      - find-method which returm object instance representing ADF component.
+     * См.
+     * https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/oracle/adf/view/js/base/AdfPage.html#findComponentByAbsoluteId_String_
+     * https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/oracle/adf/view/js/component/AdfUIComponent.html#findComponent_String__Boolean_
+    */
+
+
+    /*
+     * Methods to locate and interract with inner components of DynamicDeclarativeComponentExample
+    */  
+
+    static final String _dcot1OutputText = "dcot1";
+                    
+    public AdfOutputText find_dcot1 () {
+            return findAdfComponent(_dcot1OutputText);
+    }
+                    
+    static final String _lwdcInputTextInputText = "lwdcInputText";
+                    
+    public AdfInputText find_lwdcInputText () {
+            return findAdfComponent(_lwdcInputTextInputText);
+    }
+                    
+    static final String _dcot2OutputText = "dcot2";
+                    
+    public AdfOutputText find_dcot2 () {
+            return findAdfComponent(_dcot2OutputText);
+    }
+                    
+    static final String _dci1Iterator = "dci1";
+            
+    public static final String get_dci1Iterator() {
+        return _dci1Iterator;
+    }
+    
+    /*
+     * Methods to locate stamped-components of af:iterator.
+     * For stamped-components of af:iterator is applied general template which generates AbsoluteId and general find-Methods
+     * You need manually change them into componentId and find-by-index methods by concatinanting iterator absoluteId, index, componentId.
+     * Also Mention situation when iterators are hierarhical
+     * 
+     * Below I implement changes after xslt generation
+    */           
+                    
+    static final String _itemsTextInputText = "itemsText";
+                    
+    public AdfInputText find_itemsText (int index) {
+            return findAdfComponent(get_dci1Iterator() +":" + index + ":" +_itemsTextInputText);
+    }
+                    
+    static final String _dcot3OutputText = "dcot3";
+                    
+    public AdfOutputText find_dcot3 () {
+            return findAdfComponent(_dcot3OutputText);
+    }
+                    
+    static final String _dcot4OutputText = "dcot4";
+                    
+    public AdfOutputText find_dcot4 () {
+            return findAdfComponent(_dcot4OutputText);
+    }
+                    
+    static final String _dcot5OutputText = "dcot5";
+                    
+    public AdfOutputText find_dcot5 () {
+            return findAdfComponent(_dcot5OutputText);
+    }
+                    
+    static final String _dcot6OutputText = "dcot6";
+                    
+    public AdfOutputText find_dcot6 () {
+            return findAdfComponent(_dcot6OutputText);
+    }
+}

--- a/RichClientDemoTest/src/com/redheap/selenium/pages/DeclarativeComponentDemoPage.java
+++ b/RichClientDemoTest/src/com/redheap/selenium/pages/DeclarativeComponentDemoPage.java
@@ -1,0 +1,73 @@
+package com.redheap.selenium.pages;
+
+import com.redheap.selenium.component.AdfCommandButton;
+import com.redheap.selenium.component.AdfDynamicDeclarativeComponent;
+import com.redheap.selenium.component.AdfInputText;
+import com.redheap.selenium.component.AdfSelectOneChoice;
+import com.redheap.selenium.fragments.DynamicDeclarativeComponentExampleFragment;
+import com.redheap.selenium.page.Page;
+
+import org.openqa.selenium.WebDriver;
+
+/**
+ * Java representation of the adf-richclient-demo/faces/components/declarativeComponent.jspx page.
+ */
+public class DeclarativeComponentDemoPage extends Page {
+
+    public DeclarativeComponentDemoPage(WebDriver webDriver) {
+        super(webDriver);
+    }
+
+    @Override
+    protected String getExpectedTitle() {
+        return "Dynamic Declarative Component Demo";
+    }
+
+    /*
+     * XSLT Generated
+     * This is Page Object Model for the tested ADF Page.
+     * The model includes java code for those of Adf Faces Tag which are listed xsl:template match=. You can change this list according to your needs and re-generate code for this class.
+     * Generated code includes:
+     *      - String constant with ADF component AbsoluteId value. This constant then is used to locate component by corresponding findAdfComponent() method of SeleniumTools library.
+     *      - find-method which returm object instance representing ADF component.
+     * См.
+     * https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/oracle/adf/view/js/base/AdfPage.html#findComponentByAbsoluteId_String_
+     * https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/oracle/adf/view/js/component/AdfUIComponent.html#findComponent_String__Boolean_
+    */
+
+
+    /*
+     * Methods to locate and interract with components in the section f:facet name="first"
+    */
+
+    static final String _it1InputText = "dmoTpl:it1";
+
+    public AdfInputText find_it1() {
+        return findAdfComponent(_it1InputText);
+    }
+
+    static final String _nameTypeChoiceSelectOneChoice = "dmoTpl:nameTypeChoice";
+
+    public AdfSelectOneChoice find_nameTypeChoice() {
+        return findAdfComponent(_nameTypeChoiceSelectOneChoice);
+    }
+
+    static final String _attributeUpdateButtonCommandButton = "dmoTpl:attributeUpdateButton";
+
+    public AdfCommandButton find_attributeUpdateButton() {
+        return findAdfComponent(_attributeUpdateButtonCommandButton);
+    }
+
+    static final String _lwdcDeclarativeComponent = "dmoTpl:lwdc";
+
+    public AdfDynamicDeclarativeComponent find_lwdc() {
+        return findAdfComponent(_lwdcDeclarativeComponent);
+    }
+
+    public DynamicDeclarativeComponentExampleFragment get_lwdcDeclarativeComponentContent() {
+        //Add here code for fragment's initialization action on you page. Like: findOrderListTab().click();
+        //If declarative component rendered with load page itself then nothing additional code is needed 
+        return new DynamicDeclarativeComponentExampleFragment(find_lwdc());
+    }
+
+}

--- a/RichClientDemoTest/src/com/redheap/selenium/pages/DvtSchedulingGanttDemoPage.java
+++ b/RichClientDemoTest/src/com/redheap/selenium/pages/DvtSchedulingGanttDemoPage.java
@@ -14,6 +14,9 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
+/**
+ * Java representation of the adf-richclient-demo/faces/components/schedulingGantt.jspx page.
+ */
 public class DvtSchedulingGanttDemoPage extends Page {
 
     public DvtSchedulingGanttDemoPage(WebDriver webDriver) {

--- a/RichClientDemoTest/src/com/redheap/selenium/pages/DvtSchedulingGanttDemoPage.java
+++ b/RichClientDemoTest/src/com/redheap/selenium/pages/DvtSchedulingGanttDemoPage.java
@@ -1,0 +1,98 @@
+package com.redheap.selenium.pages;
+
+import com.redheap.selenium.component.AdfButton;
+import com.redheap.selenium.component.AdfColumn;
+import com.redheap.selenium.component.AdfCommandMenuItem;
+import com.redheap.selenium.component.AdfComponent;
+import com.redheap.selenium.component.AdfPanelGroupLayout;
+import com.redheap.selenium.component.AdfPopup;
+import com.redheap.selenium.component.DvtSchedulingGantt;
+import com.redheap.selenium.dialogs.NewFileWindowDialog;
+import com.redheap.selenium.page.Page;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+public class DvtSchedulingGanttDemoPage extends Page {
+
+    public DvtSchedulingGanttDemoPage(WebDriver webDriver) {
+        super(webDriver);
+    }
+
+    @Override
+    protected String getExpectedTitle() {
+        return "SchedulingGantt";
+    }
+
+    /*
+     * XSLT Generated
+     * This is Page Object Model for the tested ADF Page.
+     * The model includes java code for those of Adf Faces Tag which are listed xsl:template match=. You can change this list according to your needs and re-generate code for this class.
+     * Generated code includes:
+     *      - String constant with ADF component AbsoluteId value. This constant then is used to locate component by corresponding findAdfComponent() method of SeleniumTools library.
+     *      - find-method which returm object instance representing ADF component.
+     * См.
+     * https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/oracle/adf/view/js/base/AdfPage.html#findComponentByAbsoluteId_String_
+     * https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/oracle/adf/view/js/component/AdfUIComponent.html#findComponent_String__Boolean_
+    */
+
+
+    /*
+     * !-- START TAG DEMO -->
+     * Methods to locate and interract with dvt:schedulingGantt demo component
+    */
+
+    static final String _schedulingGantSchedulingGantt = "demo:schedulingGant";
+
+    public DvtSchedulingGantt find_schedulingGant() {
+        return findAdfComponent(_schedulingGantSchedulingGantt);
+    }
+
+    static final String _ta1TimeAxis = "demo:schedulingGant:ta1";
+
+    /*
+     * If you need to interract with time axis in you test you need to implement classes for AdfTimeAxis in SeleniumTools set
+    public DvtTimeAxis find_ta1() {
+        return findAdfComponent(_ta1TimeAxis);
+    }
+
+    static final String _ta2TimeAxis = "demo:schedulingGant:ta2";
+
+    public DvtTimeAxis find_ta2() {
+        return findAdfComponent(_ta2TimeAxis);
+    }
+    */
+    static final String _c1Column = "demo:schedulingGant:c1";
+
+    public AdfColumn find_c1() {
+        return findAdfComponent(_c1Column);
+    }
+
+    /*
+     * Methods to locate stamped-components in the columns of SchedulingGantt
+    */
+
+    static final String resourceNameOutputTextId = "ot1";
+
+    public static final String getresourceNameOutputTextId() {
+        return resourceNameOutputTextId;
+    }
+
+    static final String _c2Column = "demo:schedulingGant:c2";
+
+    public AdfColumn find_c2() {
+        return findAdfComponent(_c2Column);
+    }
+
+    /*
+     * Methods to locate stamped-components in the columns of SchedulingGantt
+    */
+
+    static final String departmentOutputTextId = "ot2";
+
+    public static final String getdepartmentOutputTextId() {
+        return departmentOutputTextId;
+    }
+
+}

--- a/RichClientDemoTest/src/com/redheap/selenium/pages/InputComboboxListOfValuesDemoPage.java
+++ b/RichClientDemoTest/src/com/redheap/selenium/pages/InputComboboxListOfValuesDemoPage.java
@@ -1,0 +1,68 @@
+package com.redheap.selenium.pages;
+
+import com.redheap.selenium.component.AdfInputComboboxListOfValues;
+import com.redheap.selenium.page.Page;
+
+import org.openqa.selenium.WebDriver;
+
+/**
+ * Java representation of the adf-richclient-demo/faces/components/inputComboboxListOfValues.jspx page.
+ */
+public class InputComboboxListOfValuesDemoPage extends Page {
+
+    public InputComboboxListOfValuesDemoPage(WebDriver webDriver) {
+        super(webDriver);
+    }
+
+    @Override
+    protected String getExpectedTitle() {
+        return "inputComboboxListOfValues Demo";
+    }
+
+    /*
+     * XSLT Generated 
+     * This is Page Object Model for the tested ADF Page.
+     * The model includes java code for those of Adf Faces Tag which are listed xsl:template match=. You can change this list according to your needs and re-generate code for this class.
+     * Generated code includes: 
+     *      - String constant with ADF component AbsoluteId value. This constant then is used to locate component by corresponding findAdfComponent() method of SeleniumTools library.
+     *      - find-method which returm object instance representing ADF component.
+     * См.
+     * https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/oracle/adf/view/js/base/AdfPage.html#findComponentByAbsoluteId_String_
+     * https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/oracle/adf/view/js/component/AdfUIComponent.html#findComponent_String__Boolean_
+    */
+
+
+    /*
+     * Methods to locate and interract with components in section f:facet name="seriesComponent"
+    */  
+
+    static final String _idInputComboboxListOfValues = "dmoTpl:idInputComboboxListOfValues";
+
+    public AdfInputComboboxListOfValues find_idInputComboboxListOfValues () {
+            return findAdfComponent(_idInputComboboxListOfValues);
+    }
+       
+
+    /*
+     * Methods to locate and interract with components in section f:facet name="seriesBelow"
+    */  
+
+    static final String _comboLOVwithlistener = "dmoTpl:comboLOVwithlistener";
+
+    public AdfInputComboboxListOfValues find_comboLOVwithlistener () {
+            return findAdfComponent(_comboLOVwithlistener);
+    }
+       
+    static final String _idInputComboboxListOfValues2 = "dmoTpl:idInputComboboxListOfValues2";
+
+    public AdfInputComboboxListOfValues find_idInputComboboxListOfValues2 () {
+            return findAdfComponent(_idInputComboboxListOfValues2);
+    }
+       
+    static final String _comboWithResultsTableFacet = "dmoTpl:comboWithResultsTableFacet";
+
+    public AdfInputComboboxListOfValues find_comboWithResultsTableFacet () {
+            return findAdfComponent(_comboWithResultsTableFacet);
+    }
+
+}

--- a/RichClientDemoTest/src/com/redheap/selenium/pages/InputListOfValuesDemoPage.java
+++ b/RichClientDemoTest/src/com/redheap/selenium/pages/InputListOfValuesDemoPage.java
@@ -1,0 +1,88 @@
+package com.redheap.selenium.pages;
+
+import com.redheap.selenium.component.AdfInputComboboxListOfValues;
+import com.redheap.selenium.component.AdfInputListOfValues;
+import com.redheap.selenium.component.AdfInputText;
+import com.redheap.selenium.page.Page;
+
+import org.openqa.selenium.WebDriver;
+
+/**
+ * Java representation of the adf-richclient-demo/faces/components/inputListOfValues.jspx page.
+ */
+public class InputListOfValuesDemoPage extends Page {
+
+    public InputListOfValuesDemoPage(WebDriver webDriver) {
+        super(webDriver);
+    }
+
+    @Override
+    protected String getExpectedTitle() {
+        return "inputListOfValues Demo";
+    }
+
+    /*
+     * XSLT Generated 
+     * This is Page Object Model for the tested ADF Page.
+     * The model includes java code for those of Adf Faces Tag which are listed xsl:template match=. You can change this list according to your needs and re-generate code for this class.
+     * Generated code includes: 
+     *      - String constant with ADF component AbsoluteId value. This constant then is used to locate component by corresponding findAdfComponent() method of SeleniumTools library.
+     *      - find-method which returm object instance representing ADF component.
+     * См.
+     * https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/oracle/adf/view/js/base/AdfPage.html#findComponentByAbsoluteId_String_
+     * https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/oracle/adf/view/js/component/AdfUIComponent.html#findComponent_String__Boolean_
+    */
+
+
+    /*
+     * Methods to locate and interract with components in the section f:facet name="seriesComponent"
+    */  
+
+    static final String enameInputListOfValues = "dmoTpl:idInputText";
+
+    public AdfInputListOfValues findEname () {
+            return findAdfComponent(enameInputListOfValues);
+    }
+       
+
+    /*
+     * Methods to locate and interract with components in the section f:facet name="seriesBelow" -> af:panelFormLayout id="pfl1"
+    */  
+
+    static final String empnoInputText = "dmoTpl:it1";
+
+    public AdfInputText findEmpno () {
+            return findAdfComponent(empnoInputText);
+    }
+       
+    static final String deptnoInputText = "dmoTpl:it2";
+
+    public AdfInputText findDeptno () {
+            return findAdfComponent(deptnoInputText);
+    }
+       
+    static final String hireDateInputText = "dmoTpl:it3";
+
+    public AdfInputText findHireDate () {
+            return findAdfComponent(hireDateInputText);
+    }
+       
+    static final String managerInputText = "dmoTpl:it4";
+
+    public AdfInputText findManager () {
+            return findAdfComponent(managerInputText);
+    }
+       
+    static final String salaryInputText = "dmoTpl:it5";
+
+    public AdfInputText findSalary () {
+            return findAdfComponent(salaryInputText);
+    }
+       
+    static final String commisionInputText = "dmoTpl:it6";
+
+    public AdfInputText findCommision () {
+            return findAdfComponent(commisionInputText);
+    }
+    
+}

--- a/SeleniumTools/SeleniumTools-12-2.jpr
+++ b/SeleniumTools/SeleniumTools-12-2.jpr
@@ -71,21 +71,23 @@
       <string v="oracle.toplink.workbench.addin/toplinkContentSet"/>
       <string v="oracle.bm.commonIde.data.project.ModelerProjectSettings/modelersContentSet"/>
       <string v="oracle.tip.tools.ide.fabric.addin.SCAContentSetProvider/sca-content"/>
+      <string v="oracle.tip.tools.ide.ess.addin.ESSContentSetProvider/ess-content"/>
       <string v="oracle.sb.tooling.ide.core.projects.SbProjectSettings/sbContentSet"/>
       <string v="oracle.jdeveloper.model.PathsConfiguration/cepContentSet"/>
-      <string v="oracle.tip.tools.ide.ess.addin.ESSContentSetProvider/ess-content"/>
       <string v="oracle.bpm.fusion.studio.BPMProjectSettings/bpmProjectsProcessesContentSet"/>
    </list>
    <value n="defaultPackage" v="com.redheap.selenium"/>
    <hash n="oracle.ide.model.TechnologyScopeConfiguration">
       <list n="technologyScope">
+         <string v="Ant"/>
          <string v="Java"/>
          <string v="Maven"/>
          <string v="XML"/>
       </list>
    </hash>
+   <hash n="oracle.jdeveloper.compiler.ant.AntConfiguration"/>
    <hash n="oracle.jdeveloper.compiler.OjcConfiguration">
-      <value n="internalEncoding" v="Cp1252"/>
+      <value n="internalEncoding" v="UTF-8"/>
       <value n="webIANAEncoding" v="windows-1252"/>
    </hash>
    <hash n="oracle.jdeveloper.deploy.dt.DeploymentProfiles">
@@ -109,17 +111,35 @@
                      <hash n="filters">
                         <list n="rules">
                            <hash>
-                              <value n="pattern" v="pom.xml"/>
-                              <value n="type" v="1"/>
+                              <value n="pattern" v="**"/>
+                              <value n="type" v="0"/>
                            </hash>
-                           <hash>
-                              <value n="pattern" v="SeleniumTools-12-2.jpr"/>
-                              <value n="type" v="1"/>
-                           </hash>
-                           <hash>
-                              <value n="pattern" v="SeleniumTools-12-1.jpr"/>
-                              <value n="type" v="1"/>
-                           </hash>
+                        </list>
+                     </hash>
+                     <value n="internalName" v="project-output"/>
+                     <value n="type" v="1"/>
+                  </hash>
+               </list>
+            </hash>
+            <url n="jarURL" path="../libs/selenium-tools/adf-selenium-tools.jar"/>
+            <value n="profileClass" v="oracle.jdeveloper.deploy.jar.ArchiveProfile"/>
+            <value n="profileName" v="adf-selenium-tools"/>
+         </hash>
+         <hash n="adf-selenium-tools-src">
+            <hash n="archiveOptions">
+               <value n="hasManifest" v="true"/>
+            </hash>
+            <hash n="fileGroups">
+               <list n="groups">
+                  <hash>
+                     <list n="contributors">
+                        <hash>
+                           <value n="type" v="6"/>
+                        </hash>
+                     </list>
+                     <value n="displayName" v="Project Output"/>
+                     <hash n="filters">
+                        <list n="rules">
                            <hash>
                               <value n="pattern" v="**"/>
                               <value n="type" v="0"/>
@@ -131,18 +151,17 @@
                   </hash>
                </list>
             </hash>
-            <url n="jarURL" path="deploy/adf-selenium-tools.jar"/>
+            <url n="jarURL" path="../libs/selenium-tools/adf-selenium-tools-src.jar"/>
             <value n="profileClass" v="oracle.jdeveloper.deploy.jar.ArchiveProfile"/>
-            <value n="profileName" v="adf-selenium-tools"/>
+            <value n="profileName" v="adf-selenium-tools-src"/>
          </hash>
       </hash>
       <list n="profileList">
          <string v="adf-selenium-tools"/>
+         <string v="adf-selenium-tools-src"/>
       </list>
    </hash>
-   <hash n="oracle.jdeveloper.maven.compiler.MavenConfiguration">
-      <url n="pomfileURL" path="pom.xml"/>
-   </hash>
+   <hash n="oracle.jdeveloper.maven.compiler.MavenConfiguration"/>
    <hash n="oracle.jdeveloper.model.J2eeSettings">
       <value n="j2eeWebAppName" v="AdfSelenium-SeleniumTools-webapp"/>
       <value n="j2eeWebContextRoot" v="AdfSelenium-SeleniumTools-context-root"/>
@@ -153,6 +172,7 @@
             <value n="custom" v="false"/>
             <value n="javaOptions" v="-Djava.util.logging.config.file=logging.properties"/>
             <value n="name" v="Default"/>
+            <url n="runDirectoryURL" path="."/>
             <value n="targetURL"/>
          </hash>
       </hash>
@@ -164,30 +184,16 @@
             <value n="isJDK" v="false"/>
          </hash>
          <hash>
-            <url n="id" path="../libs/Selenium Libs.library"/>
+            <url n="id" path="../libs/Selenium Libs-3-3-1.library"/>
             <value n="isJDK" v="false"/>
          </hash>
          <hash>
-            <value n="id" v="Adf-richclient-automation-12-2.jar"/>
-            <value n="isJDK" v="false"/>
-         </hash>
-         <hash>
-            <url n="id" path="../../../.jdeveloper/system12.1.3.0.41.140521.1008/o.jdeveloper/ADF 12.1.3 src.library"/>
+            <url n="id" path="../libs/Adf-richclient-automation-lite.library"/>
             <value n="isJDK" v="false"/>
          </hash>
       </list>
       <hash n="internalDefinitions">
-         <list n="libraryDefinitions">
-            <hash>
-               <list n="classPath">
-                  <url path="../libs/adf-richclient-automation-12-2.jar" jar-entry=""/>
-               </list>
-               <value n="deployedByDefault" v="true"/>
-               <value n="description" v="Adf-richclient-automation-12-2.jar"/>
-               <value n="id" v="Adf-richclient-automation-12-2.jar"/>
-               <value n="locked" v="true"/>
-            </hash>
-         </list>
+         <list n="libraryDefinitions"/>
       </hash>
       <list n="libraryReferences">
          <hash>
@@ -195,20 +201,25 @@
             <value n="isJDK" v="false"/>
          </hash>
          <hash>
-            <url n="id" path="../libs/Selenium Libs.library"/>
+            <url n="id" path="../libs/Selenium Libs-3-3-1.library"/>
             <value n="isJDK" v="false"/>
          </hash>
          <hash>
-            <value n="id" v="Adf-richclient-automation-12-2.jar"/>
-            <value n="isJDK" v="false"/>
-         </hash>
-         <hash>
-            <url n="id" path="../../../.jdeveloper/system12.1.3.0.41.140521.1008/o.jdeveloper/ADF 12.1.3 src.library"/>
+            <url n="id" path="../libs/Adf-richclient-automation-lite.library"/>
             <value n="isJDK" v="false"/>
          </hash>
       </list>
    </hash>
    <hash n="oracle.jdevimpl.config.JProjectPaths">
       <url n="outputDirectory" path="classes/"/>
+   </hash>
+   <hash n="oracle.toplink.workbench.addin">
+      <hash n="persistence-list">
+         <value n="jpa-version" v="2.0"/>
+         <value n="metamodel-generation-directory" v=""/>
+      </hash>
+   </hash>
+   <hash n="ResourceBundleOptions">
+      <list n="RegisteredResourceBundles"/>
    </hash>
 </jpr:project>

--- a/SeleniumTools/SeleniumTools-12-2.jpr
+++ b/SeleniumTools/SeleniumTools-12-2.jpr
@@ -19,7 +19,7 @@
       <value n="oracle.adfdtinternal.view.rich.binding.migration.JarResourceMigrator" v="11.1.1.1.0"/>
       <value n="oracle.adfdtinternal.view.rich.migration.ComponentIdNodeMigratorHelper" v="11.1.1.1.0.01"/>
       <value n="oracle.adfdtinternal.view.rich.migration.FacesLibraryVersionMigrator" v="11.1.1.1.0.1"/>
-      <value n="oracle.ide.model.Project" v="12.1.3.0.0;12.2.1.0.0"/>
+      <value n="oracle.ide.model.Project" v="12.1.3.0.0;12.2.1.0.0;12.2.1.3.0"/>
       <value n="oracle.ide.model.ResourcePathsMigrator" v="11.1.1.1.0"/>
       <value n="oracle.ideimpl.model.TechnologyScopeUpdateMigrator" v="11.1.2.0.0.5;11.1.2.0.0.6"/>
       <value n="oracle.jbo.dt.jclient.migrator.JCProjectMigrator" v="11.1.1.1.0"/>
@@ -54,6 +54,9 @@
       <value n="oracle.jdevimpl.webservices.WebServicesMigratorHelper" v="11.1.1.1.0"/>
       <value n="oracle.jdevimpl.xml.wl.WeblogicMigratorHelper" v="11.1.1.1.0"/>
       <value n="oracle.modeler.bmmigrate.management.Migration" v="11.1.1.1.0"/>
+      <value n="oracle.sb.tooling.ide.libs.SbProjectMigrator" v="12.1.4.0.0"/>
+      <value n="oracle.tip.tools.ide.fabric.addin.SCAProjectMigrator" v="11.1.1.1.0.13"/>
+      <value n="oracle.tip.tools.ide.workflow.addin.TaskFormMigratorAddin" v="12.1.3.0.0"/>
       <value n="oracle.toplink.workbench.addin.migration.PersistenceProjectMigrator" v="11.1.1.1.0"/>
       <value n="oracle.toplink.workbench.addin.migration.TopLinkProjectMigrator" v="11.1.1.1.0"/>
    </hash>
@@ -67,6 +70,11 @@
       <string v="oracle.adfdtinternal.model.ide.settings.ADFMSettings/adfmContentSet"/>
       <string v="oracle.toplink.workbench.addin/toplinkContentSet"/>
       <string v="oracle.bm.commonIde.data.project.ModelerProjectSettings/modelersContentSet"/>
+      <string v="oracle.tip.tools.ide.fabric.addin.SCAContentSetProvider/sca-content"/>
+      <string v="oracle.sb.tooling.ide.core.projects.SbProjectSettings/sbContentSet"/>
+      <string v="oracle.jdeveloper.model.PathsConfiguration/cepContentSet"/>
+      <string v="oracle.tip.tools.ide.ess.addin.ESSContentSetProvider/ess-content"/>
+      <string v="oracle.bpm.fusion.studio.BPMProjectSettings/bpmProjectsProcessesContentSet"/>
    </list>
    <value n="defaultPackage" v="com.redheap.selenium"/>
    <hash n="oracle.ide.model.TechnologyScopeConfiguration">

--- a/SeleniumTools/src/com/redheap/selenium/component/AdfCalendar.java
+++ b/SeleniumTools/src/com/redheap/selenium/component/AdfCalendar.java
@@ -4,6 +4,8 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 
+import java.time.Duration;
+
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
@@ -151,7 +153,7 @@ public class AdfCalendar extends AdfComponent {
     public void hoverActivityInView(int index) {
         WebElement element = findAllActivitiesInView().get(index);
         // we use pause to give javascript timer to detect hover and show popup
-        new Actions(getDriver()).moveToElement(element).pause(1000).perform();
+        new Actions(getDriver()).moveToElement(element).pause(Duration.ofMillis(1000)).perform();
         waitForPpr();
     }
 

--- a/SeleniumTools/src/com/redheap/selenium/component/AdfCommandImageLink.java
+++ b/SeleniumTools/src/com/redheap/selenium/component/AdfCommandImageLink.java
@@ -1,0 +1,11 @@
+package com.redheap.selenium.component;
+
+import org.openqa.selenium.WebDriver;
+
+public class AdfCommandImageLink extends AdfLink {
+
+    public AdfCommandImageLink(WebDriver webDriver, String clientId) {
+        super(webDriver, clientId);
+    }
+
+}

--- a/SeleniumTools/src/com/redheap/selenium/component/AdfDeclarativeComponent.java
+++ b/SeleniumTools/src/com/redheap/selenium/component/AdfDeclarativeComponent.java
@@ -1,9 +1,0 @@
-package com.redheap.selenium.component;
-
-import org.openqa.selenium.WebDriver;
-
-public class AdfDeclarativeComponent extends AdfComponent {
-    public AdfDeclarativeComponent(WebDriver webDriver, String string) {
-        super(webDriver, string);
-    }
-}

--- a/SeleniumTools/src/com/redheap/selenium/component/AdfDeclarativeComponent.java
+++ b/SeleniumTools/src/com/redheap/selenium/component/AdfDeclarativeComponent.java
@@ -1,0 +1,9 @@
+package com.redheap.selenium.component;
+
+import org.openqa.selenium.WebDriver;
+
+public class AdfDeclarativeComponent extends AdfComponent {
+    public AdfDeclarativeComponent(WebDriver webDriver, String string) {
+        super(webDriver, string);
+    }
+}

--- a/SeleniumTools/src/com/redheap/selenium/component/AdfDeclarativeComponent.java
+++ b/SeleniumTools/src/com/redheap/selenium/component/AdfDeclarativeComponent.java
@@ -4,8 +4,8 @@ import com.redheap.selenium.component.uix.UixInclude;
 
 import org.openqa.selenium.WebDriver;
 
-public class AdfDynamicDeclarativeComponent extends UixInclude {
-    public AdfDynamicDeclarativeComponent(WebDriver webDriver, String string) {
+public class AdfDeclarativeComponent extends UixInclude {
+    public AdfDeclarativeComponent(WebDriver webDriver, String string) {
         super(webDriver, string);
     }
 }

--- a/SeleniumTools/src/com/redheap/selenium/component/AdfDocument.java
+++ b/SeleniumTools/src/com/redheap/selenium/component/AdfDocument.java
@@ -8,7 +8,12 @@ public class AdfDocument extends AdfComponent {
 
     private static final String JS_SET_ANIMATION_ENABLED = "return AdfPage.PAGE.setAnimationEnabled(arguments[0])";
     private static final String JS_IS_AUTOMATION_ENABLED = "return AdfPage.PAGE.isAutomationEnabled()";
+    private static final String SUBID_page_alertConfirmDialog = "page.alertConfirmDialog";// ${path to adffacesdemo jdev project}/adffacesdemo/public_html/docs/js-subids.html#document
+    private static final String SUBID_page_alertConfirmPopup = "page.alertConfirmPopup";
+    private static final String SUBID_page_dialogService = "page.dialogService";
+    private static final String SUBID_page_messageDialog = "page.messageDialog"; 
 
+        
     public AdfDocument(WebDriver driver, String clientid) {
         super(driver, clientid);
     }
@@ -25,6 +30,22 @@ public class AdfDocument extends AdfComponent {
 
     public boolean isAutomationEnabled() {
         return (Boolean) executeScript(JS_IS_AUTOMATION_ENABLED);
+    }
+    
+    public AdfDialog findPageAlertConfirmDialog() {
+        return findSubIdComponent(SUBID_page_alertConfirmDialog);
+    }
+    
+    public AdfPopup findPageAlertConfirmPopup() {
+        return findSubIdComponent(SUBID_page_alertConfirmPopup);
+    }
+    
+    public AdfDialog findPageDialogService() {
+        return findSubIdComponent(SUBID_page_dialogService);
+    }
+    
+    public AdfDialog findPageMessageDialog() {
+        return findSubIdComponent(SUBID_page_messageDialog);
     }
 
 }

--- a/SeleniumTools/src/com/redheap/selenium/component/AdfDynamicDeclarativeComponent.java
+++ b/SeleniumTools/src/com/redheap/selenium/component/AdfDynamicDeclarativeComponent.java
@@ -1,0 +1,9 @@
+package com.redheap.selenium.component;
+
+import org.openqa.selenium.WebDriver;
+
+public class AdfDynamicDeclarativeComponent extends AdfComponent {
+    public AdfDynamicDeclarativeComponent(WebDriver webDriver, String string) {
+        super(webDriver, string);
+    }
+}

--- a/SeleniumTools/src/com/redheap/selenium/component/AdfInlineFrame.java
+++ b/SeleniumTools/src/com/redheap/selenium/component/AdfInlineFrame.java
@@ -1,0 +1,29 @@
+package com.redheap.selenium.component;
+
+import com.redheap.selenium.domain.PageMessageWrapper;
+
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+
+
+public class AdfInlineFrame extends AdfComponent {
+
+    public AdfInlineFrame(WebDriver driver, String clientid) {
+        super(driver, clientid);
+    }
+
+    /**
+     * Convenience method to get all the messages on the page.
+     * <p>
+     * This method was put here mainly so the {@link com.redheap.selenium.page.PageFragment PageFragment} has access
+     * to this method. This is because the method requires a JavascriptExecutor from a driver and PageFragment
+     * doesn't have it while you do want to ask your fragment if there are any messages if you are writing test against
+     * the taskflowtester.
+     * @return A {@link com.redheap.selenium.domain.PageMessageWrapper PageMessageWrapper} object containing
+     * all messages and some convenicence methods
+     */
+    public PageMessageWrapper getAllMessages() {
+        return PageMessageWrapper.getAllMessages((JavascriptExecutor) getDriver());
+    }
+
+}

--- a/SeleniumTools/src/com/redheap/selenium/component/AdfInputComboboxListOfValues.java
+++ b/SeleniumTools/src/com/redheap/selenium/component/AdfInputComboboxListOfValues.java
@@ -2,7 +2,13 @@ package com.redheap.selenium.component;
 
 import com.redheap.selenium.component.uix.UixInputPopup;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertNotNull;
+
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 
 public class AdfInputComboboxListOfValues extends UixInputPopup {
 
@@ -25,9 +31,29 @@ public class AdfInputComboboxListOfValues extends UixInputPopup {
         // only exists when combobox dropdown expanded
         return findSubIdComponent(SUBID_dropdownTable);
     }
+    
+    public List<String> getDropdownTableRows() {
+        AdfTable dropdownTable = findDropdownTable();
+        long ddRC = dropdownTable.getRowCount();
+        List<String> dropdownTableRows = new ArrayList<String>();
+        for (int i = 0; i < ddRC; i++) {
+            dropdownTableRows.add(dropdownTable.findRow(i).getText());     
+        }
+        return dropdownTableRows;
+    }
 
     public AdfCommandLink findSearchLink() {
         return findSubIdComponent(SUBID_searchLink);
     }
+
+    protected WebElement findDropdownIcon() {
+        return findSubIdElement(SUBID_dropdownIcon);
+    }
+    
+    public void clickDropdownIcon() {
+        findDropdownIcon().click();
+        waitForPpr();
+    }
+
 
 }

--- a/SeleniumTools/src/com/redheap/selenium/component/AdfInputComboboxListOfValues.java
+++ b/SeleniumTools/src/com/redheap/selenium/component/AdfInputComboboxListOfValues.java
@@ -32,9 +32,9 @@ public class AdfInputComboboxListOfValues extends UixInputPopup {
         return findSubIdComponent(SUBID_dropdownTable);
     }
     
-    public List<String> getDropdownTableRows() {
+    public List<String> getClientSideDropdownTableRows() {
         AdfTable dropdownTable = findDropdownTable();
-        long ddRC = dropdownTable.getRowCount();
+        long ddRC = dropdownTable. getClientRowCount();
         List<String> dropdownTableRows = new ArrayList<String>();
         for (int i = 0; i < ddRC; i++) {
             dropdownTableRows.add(dropdownTable.findRow(i).getText());     

--- a/SeleniumTools/src/com/redheap/selenium/component/AdfPanelWindow.java
+++ b/SeleniumTools/src/com/redheap/selenium/component/AdfPanelWindow.java
@@ -1,0 +1,31 @@
+package com.redheap.selenium.component;
+
+import org.openqa.selenium.WebDriver;
+
+public class AdfPanelWindow extends AdfComponent {
+
+    // see http://jdevadf.oracle.com/adf-richclient-demo/docs/js-subids.html
+    // some subids return only html tags, some return tags that are full adf components
+    private static final String SUBID_close_icon = "close_icon"; // <a> tag
+    private static final String SUBID_content = "content"; // <td> tag
+    private static final String SUBID_title = "title"; // <div> element
+
+    private static final String JS_GET_TITLE = JS_FIND_COMPONENT + "return comp.getTitle();";
+
+    public AdfPanelWindow(WebDriver webDriver, String clientid) {
+        super(webDriver, clientid);
+    }
+
+    public String getTitle() {
+        return (String) executeScript(JS_GET_TITLE, getClientId());
+    }
+    
+    public void clickCloseIcon() {
+        findCloseIcon().click();
+    }
+
+    private AdfButton findCloseIcon() {
+        return findSubIdComponent(SUBID_close_icon);
+    }
+
+}

--- a/SeleniumTools/src/com/redheap/selenium/component/AdfQuery.java
+++ b/SeleniumTools/src/com/redheap/selenium/component/AdfQuery.java
@@ -1,11 +1,49 @@
 package com.redheap.selenium.component;
 
+import com.redheap.selenium.component.uix.UixInput;
+
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 
 public class AdfQuery extends AdfComponent {
 
+    // SubIds for components of InputPopup's RichQuery section
+    private static final String SUBID_criterion_label = "criterion_label";// element for search criteria field X. Here X is a digit refers to criterion index. Interanal Client SubId crtnLab
+    private static final String SUBID_criterion_operator = "criterion_operator";// element for search criteria operator (as "Between"). For example value=1. Here the digit refers to criterion index.
+    private static final String SUBID_criterion_value = "criterion_value";// element for search criteria field XY. 
+                                                                          // Here the first digit X refers to criterion index and second digit Y is the index of the value field of that criterion.
+                                                                          // As in case "Between" operator there are two value fields having "value" such as 20 and 21.
+    private static final String SUBID_search_button = "search_button";// element for search button.
+    private static final String SUBID_reset_search_button =  "reset_button";
+    
+    
     public AdfQuery(WebDriver webDriver, String clientid) {
         super(webDriver, clientid);
     }
 
+    public <T extends UixInput> T findCriterionValueFieldByIndex(int criterionIndex, int valueFieldIndex) {
+        // Here the first digit of index refers to criterion index and second digit is the index of the value field of that criterion.
+        // As in case "Between" operator there are two value fields having "value" such as 20 and 21.
+        return findSubIdComponent(SUBID_criterion_value + "["+ criterionIndex + valueFieldIndex + "]");
+    }
+    
+    protected WebElement findPopupQuerySearchButton() {
+        return findSubIdElement(SUBID_search_button);
+    }
+    
+    protected WebElement findPopupQueryResetSearchButton() {
+        return findSubIdElement(SUBID_reset_search_button); 
+    }
+        
+    public void clickPopupQuerySearchButton() {
+        findPopupQuerySearchButton().click();
+        waitForPpr();
+    }
+    
+    public void clickPopupQueryResetSearchButton() {
+        findPopupQueryResetSearchButton().click();
+        waitForPpr();
+    }
+
+    
 }

--- a/SeleniumTools/src/com/redheap/selenium/component/AdfShowDetailItem.java
+++ b/SeleniumTools/src/com/redheap/selenium/component/AdfShowDetailItem.java
@@ -7,6 +7,12 @@ public class AdfShowDetailItem extends AdfComponent {
     // see javascript AdfDhtmlShowDetailItemPeer.prototype.GetSubIdDomElement
     // see http://jdevadf.oracle.com/adf-richclient-demo/docs/js-subids.html
     private static final String SUBID_tab_link = "tab_link";
+    
+    private static final String JS_IS_SHOW_ITEM_DISCLOSED =
+        JS_FIND_COMPONENT + "return comp.getDisclosed();";
+    
+    private static final String JS_GET_HEADER_TEXT =
+        JS_FIND_COMPONENT + "return comp.getText();";
 
     public AdfShowDetailItem(WebDriver webDriver, String clientid) {
         super(webDriver, clientid);
@@ -20,6 +26,14 @@ public class AdfShowDetailItem extends AdfComponent {
     public void clickTabLink() {
         findSubIdElement(SUBID_tab_link).click();
         waitForPpr();
+    }
+    
+    public boolean isDisclosed() {
+        return (Boolean) executeScript(JS_IS_SHOW_ITEM_DISCLOSED, getClientId());
+    }
+    
+    public String getHeaderText() {
+        return (String) executeScript(JS_GET_HEADER_TEXT, getClientId());
     }
 
 }

--- a/SeleniumTools/src/com/redheap/selenium/component/AdfTable.java
+++ b/SeleniumTools/src/com/redheap/selenium/component/AdfTable.java
@@ -52,10 +52,12 @@ public class AdfTable extends AdfComponent {
             "        d && (d = AdfAgent.AGENT.getAttribute(d, \"_leafColClientIds\"),\n" + 
             "        d = eval(d))\n" + 
             "        if (d) {\n" + 
-            "            for (var h = 0; h < d.length && !retval; h++) {\n" + 
-            "                if (d[h].indexOf(cId) !== -1 ) {\n" + 
-            "                    retval = h;\n" + 
-            "                    break\n" + 
+            "            for (var h = 0; h < d.length && !retval; h++) {\n" +
+            "                if (d[h] !== null) {" +                      //this check covers header with joint columns
+            "                   if (d[h].indexOf(cId) !== -1 ) {\n" + 
+            "                        retval = h;\n" + 
+            "                        break\n" + 
+            "                   }\n" +
             "                }\n" + 
             "            }\n" + 
             "        }\n" + 
@@ -215,7 +217,7 @@ public class AdfTable extends AdfComponent {
     
     public void selectRow(String columnComponentId, String cellValue) {
         Map<?, ?> rowinfo = (Map<?, ?>) findRowWithInfo(columnComponentId, cellValue);
-        assertNotNull("задача отсутсвует в task list", rowinfo);
+        assertNotNull("Row with specified cellValue are not in the Table", rowinfo);
         Long index = (Long)rowinfo.get("index");
         scrollToRowIndex(index.intValue());
         WebElement row = (WebElement)rowinfo.get("tr");
@@ -254,12 +256,12 @@ public class AdfTable extends AdfComponent {
     }
 
     public WebElement findRow(int index) {
-        return (WebElement) executeScript(JS_GET_ROW_BY_INDEX, getClientId(), String.valueOf(index));
+        return (WebElement) executeScript(JS_GET_ROW_BY_INDEX, getClientId(), index);
     }
     
     public WebElement findRow(String columnComponentId, String cellValue){
         Map<?, ?> rowinfo = (Map<?, ?>) findRowWithInfo(columnComponentId, cellValue);
-        assertNotNull("задача отсутсвует в task list", rowinfo);
+        assertNotNull("Row with specified cellValue are not in the Table", rowinfo);
         return (WebElement) rowinfo.get("tr");
     }
     

--- a/SeleniumTools/src/com/redheap/selenium/component/AdfTable.java
+++ b/SeleniumTools/src/com/redheap/selenium/component/AdfTable.java
@@ -1,13 +1,22 @@
 package com.redheap.selenium.component;
 
+import com.google.common.collect.Maps;
+
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertNotNull;
 
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.internal.JsonToWebElementConverter;
 
 public class AdfTable extends AdfComponent {
 
@@ -33,8 +42,54 @@ public class AdfTable extends AdfComponent {
         "var keys=Object.keys(comp.getDisclosedRowKeys()); var retval=[]; keys.forEach(function(key){retval.push(peer.getRowIndex(key))}); return retval;";
     private static final String JS_GET_ROW_BY_INDEX =
         JS_FIND_PEER +
-        "var rowinfo=peer.FindRowByKey(peer.getRowIndex(arguments[1])); if (rowinfo){return rowinfo.tr}else{return null}";
+        "var rowinfo=peer.FindRowByKey(peer.getRowKey(arguments[1])); if (rowinfo){return rowinfo.tr}else{return null}"; //Fixed defect: was peer.getRowIndex instead of peer.getRowKey
+    private static final String JS_GET_COLUMN_INDEX_BY_ID =
+            JS_FIND_PEER + 
+            "getColumnIndexById = function(cId) {\n" + 
+            "    var retval;\n" + 
+            "    if (!peer._headerless) {\n" + 
+            "        var d = peer.getDomElement();\n" + 
+            "        d && (d = AdfAgent.AGENT.getAttribute(d, \"_leafColClientIds\"),\n" + 
+            "        d = eval(d))\n" + 
+            "        if (d) {\n" + 
+            "            for (var h = 0; h < d.length && !retval; h++) {\n" + 
+            "                if (d[h].indexOf(cId) !== -1 ) {\n" + 
+            "                    retval = h;\n" + 
+            "                    break\n" + 
+            "                }\n" + 
+            "            }\n" + 
+            "        }\n" + 
+            "    }\n" + 
+            "    return retval\n" + 
+            "};" +
+            "return getColumnIndexById(arguments[1]);";
+        
+    
+    private static final String JS_GET_ROW_BY_COLUMN_VALUE =
+        JS_FIND_PEER +
+        "FindRowByColumnValue = function(cIdx, cVal) {\n" + 
+        "    for (var retval = null, d = peer.GetDataBody().childNodes, e = 0; e < d.length && !retval; e++) {\n" + 
+        "        var f = d[e]\n" + 
+        "          , g = f.rows;\n" + 
+        "        if (g)\n" + 
+        "            for (var h = 0; h < g.length && !retval; h++) {\n" + 
+        "                var k = g[h];\n" + 
+        "                if (cIdx && k.childNodes[cIdx].textContent.indexOf(cVal) !== -1) {\n" + 
+        "                    retval = {\n" + 
+        "                        tr: k,\n" + 
+        "                        index: f.startRow + h,\n" + 
+        "                        block: f\n" + 
+        "                    };\n" + 
+        "                    break\n" + 
+        "                }\n" + 
+        "            }\n" + 
+        "    }\n" + 
+        "    return retval\n" + 
+        "};" +
+        "return FindRowByColumnValue(arguments[1],arguments[2]);";
+    
     private static final String JS_GET_ROW_COUNT = JS_FIND_PEER + "return peer.GetRowCount();";
+    private static final String JS_IS_EMPTY = JS_FIND_COMPONENT + "return comp.isEmpty();";
 
     public AdfTable(WebDriver webDriver, String clientid) {
         super(webDriver, clientid);
@@ -49,6 +104,19 @@ public class AdfTable extends AdfComponent {
         return AdfComponent.forClientId(getDriver(), clientid);
     }
 
+    /**
+     * @param <T>
+     * @param relativeClientId
+     * @param rowIndex
+     * @return
+     * see https://docs.oracle.com/middleware/1221/adf/api-reference-javascript-faces/org/apache/myjs/trinidad/component/AdfUITable.html
+     * AdfUITable provides this overload of AdfUIComponent.findComponent() which takes an (optional) row key. 
+     * When the row key is specified, AdfUITable.findComponent() returns the stamped component instance for the specified row. 
+     * Note that the actual row key value may be transformed by the rich client framework such that the client-side value of
+     * the row key may not have any resemblance to the server-side row key. 
+     * As such, only row keys served up by the client-side framework (eg. row keys obtained from selection events)
+     * should be passed to AdfUITable.findComponent().
+     */
     public <T extends AdfComponent> T findAdfComponent(String relativeClientId, int rowIndex) {
         scrollToRowIndex(rowIndex); // scroll to row (and possibly fetch additional data)
         String clientid =
@@ -63,7 +131,11 @@ public class AdfTable extends AdfComponent {
         retval.scrollIntoView();
         return retval;
     }
-
+    
+    public boolean isEmpty () {
+        return (Boolean) executeScript(JS_IS_EMPTY, getClientId());
+    }
+    
     public List<Integer> getSelectedRows() {
         return rowIndices((List<Long>) executeScript(JS_SELECTED_ROWS, getClientId()));
     }
@@ -140,6 +212,24 @@ public class AdfTable extends AdfComponent {
         row.click();
         waitForPpr();
     }
+    
+    public void selectRow(String columnComponentId, String cellValue) {
+        Map<?, ?> rowinfo = (Map<?, ?>) findRowWithInfo(columnComponentId, cellValue);
+        assertNotNull("задача отсутсвует в task list", rowinfo);
+        Long index = (Long)rowinfo.get("index");
+        scrollToRowIndex(index.intValue());
+        WebElement row = (WebElement)rowinfo.get("tr");
+        row.click();
+        waitForPpr();
+    }
+    
+    public boolean checkFindRow(String columnComponentId, String cellValue) {
+        Map<?, ?> rowinfo = (Map<?, ?>) findRowWithInfo(columnComponentId, cellValue);
+        if(rowinfo == null) 
+            return false;
+        else
+            return true;
+    }
 
     public void selectToRow(int index) {
         scrollToRowIndex(index);
@@ -163,8 +253,35 @@ public class AdfTable extends AdfComponent {
         return findSubIdElement("[" + index + "]" + SUBID_disclosureID);
     }
 
-    protected WebElement findRow(int index) {
+    public WebElement findRow(int index) {
         return (WebElement) executeScript(JS_GET_ROW_BY_INDEX, getClientId(), String.valueOf(index));
     }
+    
+    public WebElement findRow(String columnComponentId, String cellValue){
+        Map<?, ?> rowinfo = (Map<?, ?>) findRowWithInfo(columnComponentId, cellValue);
+        assertNotNull("задача отсутсвует в task list", rowinfo);
+        return (WebElement) rowinfo.get("tr");
+    }
+    
+    /**
+     * @param columnComponentId
+     * @param cellValue - row will be selected by matching this value and value in the cell in the column {@code columnComponentId}
+     * @return
+     */
+    protected Object findRowWithInfo(String columnComponentId, String cellValue) {
+        int cIdx = getColumnIndex(columnComponentId);
+        return executeScript(JS_GET_ROW_BY_COLUMN_VALUE, getClientId(), cIdx, cellValue);
+    }
+    
+    /**
+     * @param columnComponentId
+     * @return index of table colunm based on {@param columnComponentId}
+     */
+    protected int getColumnIndex(String columnComponentId) {
+        return ((Number) executeScript(JS_GET_COLUMN_INDEX_BY_ID, getClientId(), columnComponentId)).intValue();
+    }
 
+
+    public void getRowCount(Integer contractNameRow) {
+    }
 }

--- a/SeleniumTools/src/com/redheap/selenium/component/AdfTable.java
+++ b/SeleniumTools/src/com/redheap/selenium/component/AdfTable.java
@@ -91,6 +91,7 @@ public class AdfTable extends AdfComponent {
         "return FindRowByColumnValue(arguments[1],arguments[2]);";
     
     private static final String JS_GET_ROW_COUNT = JS_FIND_PEER + "return peer.GetRowCount();";
+    private static final String JS_GET_CLIENT_ROW_COUNT = JS_FIND_PEER + "return peer.getClientRowCount();";
     private static final String JS_IS_EMPTY = JS_FIND_COMPONENT + "return comp.isEmpty();";
 
     public AdfTable(WebDriver webDriver, String clientid) {
@@ -207,6 +208,10 @@ public class AdfTable extends AdfComponent {
     public long getRowCount() {
         return ((Number) executeScript(JS_GET_ROW_COUNT, getClientId())).longValue();
     }
+    
+    public long getClientRowCount() {
+        return ((Number) executeScript(JS_GET_CLIENT_ROW_COUNT, getClientId())).longValue();
+    }
 
     public void selectRow(int index) {
         scrollToRowIndex(index);
@@ -283,7 +288,4 @@ public class AdfTable extends AdfComponent {
         return ((Number) executeScript(JS_GET_COLUMN_INDEX_BY_ID, getClientId(), columnComponentId)).intValue();
     }
 
-
-    public void getRowCount(Integer contractNameRow) {
-    }
 }

--- a/SeleniumTools/src/com/redheap/selenium/component/AdfToolbar.java
+++ b/SeleniumTools/src/com/redheap/selenium/component/AdfToolbar.java
@@ -1,0 +1,35 @@
+package com.redheap.selenium.component;
+
+import com.redheap.selenium.errors.SubIdNotFoundException;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+public class AdfToolbar extends AdfComponent {
+    private static final String JS_FIND_TOOLBAR_BUTTON_SUBID_CLIENTID =
+        JS_FIND_PEER + "var subelem=peer.getSubIdDomElement(comp,arguments[1]).firstElementChild;" +
+                       "if(!subelem){return null;}return AdfRichUIPeer.getFirstAncestorComponent(subelem).getClientId();";
+    
+    // see http://jdevadf.oracle.com/adf-richclient-demo/docs/js-subids.html
+    private static final String SUBID_startPart_item = "item["; //item[#]	an item, corresponding to the #, on the toolbar
+    private static final String SUBID_endtPart_item = "]";     //correspondes to <td> element, but not to <div> of CommandToolbarButton
+
+    public AdfToolbar(WebDriver webDriver, String clientid) {
+        super(webDriver, clientid);
+    }
+
+    protected <T extends AdfComponent> T findToolbarSubIdComponent(String subid) {
+        final String subClientId = (String) executeScript(JS_FIND_TOOLBAR_BUTTON_SUBID_CLIENTID, getClientId(), subid);
+        if (subClientId == null) {
+            return null;
+        }
+        return AdfComponent.forClientId(getDriver(), subClientId);
+    }
+
+    public AdfCommandToolbarButton findCommandToolbarButton(int itemIndex) {
+        return findToolbarSubIdComponent(SUBID_startPart_item + itemIndex + SUBID_endtPart_item);
+        //findSubIdElement(SUBID_tab_link).click();
+        //waitForPpr();
+    }
+
+}

--- a/SeleniumTools/src/com/redheap/selenium/component/AutoSuggestBehavior.java
+++ b/SeleniumTools/src/com/redheap/selenium/component/AutoSuggestBehavior.java
@@ -1,12 +1,12 @@
 package com.redheap.selenium.component;
 
-import com.google.common.base.Predicate;
-
 import com.redheap.selenium.component.uix.UixInput;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import java.util.function.Function;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
@@ -79,9 +79,9 @@ public class AutoSuggestBehavior<C extends UixInput> {
         component.clear();
         component.sendKeys(Keys.BACK_SPACE, value);
         final AdfComponent comp = component;
-        new WebDriverWait(component.getDriver(), 10, 100).until(new Predicate<WebDriver>() {
+        new WebDriverWait(component.getDriver(), 10, 100).until(new Function<WebDriver, Boolean>() { //Refactor for using <V extends Object> V until(Function<? super T, V> p1) instead of deprected in 3.3.1 void until(Predicate<T> p1) 
             @Override
-            public boolean apply(WebDriver webDriver) {
+            public Boolean apply(WebDriver webDriver) {
                 if (isPopupVisible()) {
                     comp.waitForPpr();
                     return true;

--- a/SeleniumTools/src/com/redheap/selenium/component/DvtSchedulingGantt.java
+++ b/SeleniumTools/src/com/redheap/selenium/component/DvtSchedulingGantt.java
@@ -1,0 +1,171 @@
+package com.redheap.selenium.component;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
+
+public class DvtSchedulingGantt extends AdfComponent {
+
+    // see http://jdevadf.oracle.com/adf-richclient-demo/docs/js-subids.html
+    // some subids return only html tags, some return tags that are full adf components
+
+    private static final String SUBID_zoom_in_button = "toolbar#zoomIn"; // TimeAxes Toolbar Button
+    private static final String SUBID_zoom_out_button = "toolbar#zoomOut"; // TimeAxes Toolbar Button
+    private static final String SUBID_zoom_to_fit_button = "toolbar#zoomToFit"; // TimeAxes Toolbar Button
+
+    private static final String JS_GET_DATA_TREE_TABLE_ABSOLUTE_ID = 
+        JS_FIND_PEER + 
+        "return peer.getDataTreeTableId()";
+    private static final String JS_GET_CHART_TREE_TABLE_ABSOLUTE_ID = 
+        JS_FIND_PEER + 
+        "return peer.getChartTreeTableId();";
+    private static final String JS_GET_TASK_BAR_ELEMENT = 
+        JS_FIND_PEER + 
+        "var taskbarelem=peer.getTaskbarElement(arguments[1],arguments[2],\"bar\"); return taskbarelem?taskbarelem :null;";
+    private static final String JS_SELECT_TASK = 
+        JS_FIND_PEER + 
+        "var taskbarelem=peer.getTaskbarElement(arguments[1],arguments[2],\"bar\");" +
+        "peer.removeSelectedTasks();" +
+        "peer.selectTask(taskbarelem);"; 
+    /* SUBIDs
+     * 
+     * [row index][task index]taskbar	A task bar at a specific row with a specific task
+     * dataTreeTable[(level 0 index)]...[(level N child index)]disclosureID	Disclosure indicator specified via an array of level based indexes
+     * dataTreeTable[(row index)]:(stamp id)	Stamped component at a specific row
+     * taskMenu#create	Create menu
+     * toolbar#zoomIn	Zoom in button
+     * toolbar#zoomOut	Zoom out button
+     * toolbar#zoomToFit	Zoom to fit combo
+     * splitter	Splitter
+     * ___________
+     * gantt=AdfPage.PAGE.findComponent("sg1");
+     * peer=gantt.getPeer();
+     * peer.bind(gantt);
+     * peer.getChartTreeTableId();
+            "sg1:ctt"
+     * peer.getDataTreeTableId();
+     *      "sg1:dtt"
+
+     * dtt=AdfPage.PAGE.findComponent("sg1:dtt"); ---> JS_FIND_DATA_TREE_TABLE
+     *      _componentType: "oracle.adf.RichTreeTable", _clientId: "sg1:dtt",
+     * child=dtt.findComponent("ot4",4); ---> AdfTree.findAdfComponent(String relativeClientId, int rowIndex)
+     *      _componentType: "oracle.adf.RichOutputText", _clientId: "sg1:dtt:4:ot4"
+     * ___________     
+     * subelem=peer.getSubIdDomElement(gantt,"dataTreeTable[1]:ot4"); ---> Оставить без реализации, так как дублируется тем что выше
+           <span id=​"sg1:​dtt:​1:​ot4">​21827​</span>​
+     * subcomp=AdfRichUIPeer.getFirstAncestorComponent(subelem);
+     * ____________
+     * peer.getSubIdDomElement(gantt,"resourceMenu"); ---> Оставить без реализации, т.к. у нас не используется
+     *      <div id="sg1:_resMenu"
+     * peer.getSubIdDomElement(gantt,"taskMenu"); ---> Оставить без реализации, т.к. у нас меню свое вместо стандартного     
+     *     <div id="sg1:_taskMenu"  
+     * peer.getSubIdDomElement(gantt,"toolbar#zoomIn");
+     *     <div id="sg1:_bZi" title="Увеличить"
+     *______________
+     * 
+     * <div id="sg1:ctt:0:tsb" - сторока с bar'ами задач планировщика
+     * <div id="sg1:ctt:ROW_ID:tsb"
+     * <div tid="1214715" st="1537131600000" et="1537217999000" class="x1l8 x1ps" style="left:319px;height:14px;width:21px;"> - это сам bar
+     * tid="TASK_ID из property" 
+     * st="время старта в миллисекундах"
+     * et="время завершения в миллисекундах"  ---> см. https://currentmillis.com/
+     * 
+     * 
+     * peer.getSubIdDomElement(gantt,"[ROW_ID][tid]taskbar"); - вариант через SubId
+     * или
+     * peer.getTaskbarElement(0,1214715,"bar"); - вариант через JS API ---> JS_GET_TASK_BAR_ELEMENT, JS_SELECT_TASK
+     * ______________1303314
+     * peer.getChartRowContextMenuId()
+            "p7"
+     * 
+     * 
+     * 
+     * peer.getDataTreeTableDomElement();
+     * peer.GetBestMatchSubId(peer.getDataTreeTableDomElement());
+            "splitter"
+
+
+     * peer.getSubIdDomElement(gantt,"[0][0]taskbar");
+     */
+
+    public DvtSchedulingGantt(WebDriver webDriver, String clientid) {
+        super(webDriver, clientid);
+    }
+
+    public <T extends AdfComponent> T findDataTreeTable() {
+        String clientid =
+            (String) executeScript(JS_GET_DATA_TREE_TABLE_ABSOLUTE_ID, getClientId());
+        if (clientid == null) {
+            return null;
+        }
+        return AdfComponent.forClientId(getDriver(), clientid);
+    }
+
+    public <T extends AdfComponent> T findChartTreeTable() {
+        String clientid =
+            (String) executeScript(JS_GET_CHART_TREE_TABLE_ABSOLUTE_ID, getClientId());
+        if (clientid == null) {
+            return null;
+        }
+        return AdfComponent.forClientId(getDriver(), clientid);
+    }
+
+    /*
+     *This element represents Gantt Chart Row | <tr role="row" _afrrk="2" aria-level="1" _afrip="2" class="x14o">
+     *  and rowKey here is _afrrk="2"
+     *                                        |     <td style="padding:0px;" nowrap="" role="gridcell" id="sg1:ctt:2:tsbc" class="xia x1kz">
+     *                                        |          <span class="af_column_data-container" style="white-space: nowrap">
+     *This element represents Task            |              <div id="sg1:ctt:2:tsb" down="sd" onmousewheel="hmw(event, 'sg1')" resid="32109" style="position:relative;height:44px;width:1820px;">
+     *   and rowIndex here is :2:           
+     *This element represents TaskBar         |                  <div tid="1210051" st="1536872400000" et="1536958799000"....
+     *   and TASK_ID here is tid="1210051"
+     *       st="task start time in milliseconds"
+     *       et="task end time in milliseconds"  ---> check convertion at https://currentmillis.com/
+     *       
+     *There are two ways to get these data:
+     *  1) peer.getSubIdDomElement(gantt,"[ROW_ID][tid]taskbar"); ---> through SubId
+     *  or
+     *  2) peer.getTaskbarElement(0,1214715,"bar"); ---> through JS API --> this one is implemanted in this class
+     */
+    private WebElement findTaskbar (int rowIndex, String taskId) {
+        WebElement taskBarElement = (WebElement) executeScript(JS_GET_TASK_BAR_ELEMENT, getClientId(), rowIndex, taskId);
+        waitForPpr();
+        return taskBarElement;
+    }
+    
+    public void taskbarSelect (int rowIndex, String taskId) {
+        executeScript(JS_SELECT_TASK, getClientId(), rowIndex, taskId);
+        waitForPpr();
+    }
+
+    public void taskbarContextClick (int rowIndex, String taskId) {
+        WebElement taskBarElement = findTaskbar (rowIndex, taskId);
+        new Actions(this.getDriver()).contextClick(taskBarElement).perform();
+        waitForPpr();
+    }    
+    
+    
+    
+    private AdfButton findZoomInButton() {
+        return findSubIdComponent(SUBID_zoom_in_button);
+    }
+
+    private AdfButton findZoomOutButton() {
+        return findSubIdComponent(SUBID_zoom_out_button);
+    }
+
+
+
+    public void ClickZoomIn() {
+        findZoomInButton().click();
+    }
+
+    public void ClickZoomOutButton() {
+        findZoomOutButton().click();
+    }
+
+    public AdfSelectOneChoice findZoomToFitButon() {
+        return findSubIdComponent(SUBID_zoom_to_fit_button);
+    }
+
+}

--- a/SeleniumTools/src/com/redheap/selenium/component/DvtSchedulingGantt.java
+++ b/SeleniumTools/src/com/redheap/selenium/component/DvtSchedulingGantt.java
@@ -22,9 +22,15 @@ public class DvtSchedulingGantt extends AdfComponent {
     private static final String JS_GET_TASK_BAR_ELEMENT = 
         JS_FIND_PEER + 
         "var taskbarelem=peer.getTaskbarElement(arguments[1],arguments[2],\"bar\"); return taskbarelem?taskbarelem :null;";
+    private static final String JS_SCROLL_INTO_VIEW = 
+        JS_FIND_PEER + 
+        "peer.scrollInToView(peer.findElement(arguments[1],'tid'));";
+    
     private static final String JS_SELECT_TASK = 
         JS_FIND_PEER + 
         "var taskbarelem=peer.getTaskbarElement(arguments[1],arguments[2],\"bar\");" +
+        "var task=peer.findElement(taskbarelem,'tid');" +
+        "peer.scrollInToView(task);" +
         "peer.removeSelectedTasks();" +
         "peer.selectTask(taskbarelem);"; 
     /* SUBIDs
@@ -133,6 +139,7 @@ public class DvtSchedulingGantt extends AdfComponent {
         return taskBarElement;
     }
     
+    
     public void taskbarSelect (int rowIndex, String taskId) {
         executeScript(JS_SELECT_TASK, getClientId(), rowIndex, taskId);
         waitForPpr();
@@ -140,17 +147,18 @@ public class DvtSchedulingGantt extends AdfComponent {
 
     public void taskbarContextClick (int rowIndex, String taskId) {
         WebElement taskBarElement = findTaskbar (rowIndex, taskId);
+        executeScript(JS_SCROLL_INTO_VIEW,getClientId(), taskBarElement);
         new Actions(this.getDriver()).contextClick(taskBarElement).perform();
         waitForPpr();
     }    
     
     
     
-    private AdfButton findZoomInButton() {
+    public AdfButton findZoomInButton() {
         return findSubIdComponent(SUBID_zoom_in_button);
     }
 
-    private AdfButton findZoomOutButton() {
+    public AdfButton findZoomOutButton() {
         return findSubIdComponent(SUBID_zoom_out_button);
     }
 

--- a/SeleniumTools/src/com/redheap/selenium/component/uix/UixInclude.java
+++ b/SeleniumTools/src/com/redheap/selenium/component/uix/UixInclude.java
@@ -1,0 +1,11 @@
+package com.redheap.selenium.component.uix;
+
+import com.redheap.selenium.component.AdfComponent;
+
+import org.openqa.selenium.WebDriver;
+
+public class UixInclude extends AdfComponent {
+    public UixInclude(WebDriver webDriver, String string) {
+        super(webDriver, string);
+    }
+}

--- a/SeleniumTools/src/com/redheap/selenium/component/uix/UixInput.java
+++ b/SeleniumTools/src/com/redheap/selenium/component/uix/UixInput.java
@@ -6,7 +6,6 @@ import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.interactions.Actions;
 
 public abstract class UixInput extends UixValue {
 
@@ -66,6 +65,14 @@ public abstract class UixInput extends UixValue {
         sendKeys(value);
         tabNext();
     }
+
+    public void typeValueWithoutTab(String value) {
+        clear();
+        sendKeys(value);
+        
+    }
+
+
 
     /**
      * Private method that will give back the {@link com.redheap.selenium.domain.PageMessageWrapper PageMessageWrapper}.

--- a/SeleniumTools/src/com/redheap/selenium/component/uix/UixInput.java
+++ b/SeleniumTools/src/com/redheap/selenium/component/uix/UixInput.java
@@ -6,6 +6,7 @@ import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.interactions.Actions;
 
 public abstract class UixInput extends UixValue {
 

--- a/SeleniumTools/src/com/redheap/selenium/component/uix/UixInputPopup.java
+++ b/SeleniumTools/src/com/redheap/selenium/component/uix/UixInputPopup.java
@@ -11,9 +11,12 @@ import org.openqa.selenium.WebDriver;
 
 public abstract class UixInputPopup extends UixInput {
 
+    // see http://jdevadf.oracle.com/adf-richclient-demo/docs/js-subids.html
     private static final String SUBID_content = "content"; // <input> element
     private static final String SUBID_label = "label"; // <label> element
+    // All list of inner SubIds of InputPopup's RichQuery section see in AdfQuery class
     private static final String SUBID_lovDialog_query = "lovDialog_query"; // RichQuery
+    //SubIds for components of InputPopup's search result Table
     private static final String SUBID_lovDialog_table = "lovDialog_table"; // Table
     private static final String SUBID_lovDialog_table_cellContainer = "lovDialog_table_cellContainer"; // <td> element
     private static final String SUBID_lovDialog_table_columnHeader_text =
@@ -26,9 +29,30 @@ public abstract class UixInputPopup extends UixInput {
         super(webDriver, clientid);
     }
 
+    public AdfPopup findSearchDialogPopup() {
+        return findSubIdComponent(SUBID_search_dialog_popup);
+    }
+
+    public boolean isPopupVisible() {
+        AdfPopup popup = findSearchDialogPopup();
+        return popup != null && popup.isPopupVisible();
+    }
+
+    public AdfDialog findSearchDialog() {
+        return findSubIdComponent(SUBID_search_dialog);
+    }
+
+    /*
+     * Methods for locating components of InputPopup's RichQuery section
+    */
+
     public AdfQuery findLovDialogQuery() {
         return findSubIdComponent(SUBID_lovDialog_query);
     }
+
+    /*
+     * Methods for locating components of InputPopup's search result Table
+    */
 
     public AdfTable findLovDialogTable() {
         return findSubIdComponent(SUBID_lovDialog_table);
@@ -40,19 +64,6 @@ public abstract class UixInputPopup extends UixInput {
 
     public AdfOutputText findLovDialogTableCell(int rowIndex, int colIndex) {
         return findSubIdComponent(SUBID_lovDialog_table + "[" + rowIndex + "][" + colIndex + "]");
-    }
-
-    public AdfDialog findSearchDialog() {
-        return findSubIdComponent(SUBID_search_dialog);
-    }
-
-    public boolean isPopupVisible() {
-        AdfPopup popup = findSearchDialogPopup();
-        return popup != null && popup.isPopupVisible();
-    }
-
-    public AdfPopup findSearchDialogPopup() {
-        return findSubIdComponent(SUBID_search_dialog_popup);
     }
 
 }

--- a/SeleniumTools/src/com/redheap/selenium/junit/FirefoxDriverResource.java
+++ b/SeleniumTools/src/com/redheap/selenium/junit/FirefoxDriverResource.java
@@ -1,80 +1,49 @@
 package com.redheap.selenium.junit;
 
 import java.util.Locale;
-import java.util.logging.Logger;
 
+import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.FirefoxProfile;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
 public class FirefoxDriverResource extends WebDriverResource {
 
-    private static final Logger logger = Logger.getLogger(FirefoxDriverResource.class.getName());
 
-    /**
-     * From Selenium 3 on, Firefox is launched using Geckodriver (see: <a href="https://github.com/mozilla/geckodriver/releases">
-     * https://github.com/mozilla/geckodriver/releases</a>) unless it is specified by means of system property
-     * {@code webdriver.firefox.marionette} that the new geckodriver (marionette) is not to be used, but the legacy firefox driver
-     * instead.
-     * <p>
-     * If the new driver is to be used, we need a path to it's executable which should be set in system property
-     * {@code webdriver.gecko.driver} before creation of the driver.
-     *
-     * @param width
-     * @param height
-     * @param locale
-     * @param forceLegacyDriver Indicates if the legacy firefox driver should be used instead of the new geckodriver
-     */
-    public FirefoxDriverResource(final int width, final int height, final Locale locale, final boolean forceLegacyDriver) {
+    public FirefoxDriverResource(int width, int height, Locale locale) {
         super(width, height, locale);
-        if (forceLegacyDriver) {
-            logger.fine("Force use of legacy firefox driver: webdriver.firefox.marionette=false");
-            System.setProperty("webdriver.firefox.marionette", Boolean.FALSE.toString());
-        }
     }
-
-    /**
-     * See {@link #FirefoxDriverResource(int, int, Locale, boolean)}, only without forcing the use of the legacy driver.
-     *
-     * @param width
-     * @param height
-     * @param locale
-     */
-    public FirefoxDriverResource(final int width, final int height, final Locale locale) {
-        this(width, height, locale, false);
-    }
-
-    /**
-     * Get default instance, but give a path to Geckodriver executable.
-     */
+    
     public FirefoxDriverResource() {
         super();
     }
 
-    /**
-     * {@inheritDoc}.
-     * @param language
-     * @return
-     */
     @Override
-    protected RemoteWebDriver createDriver(final String language) {
-        final RemoteWebDriver driver = new FirefoxDriver(createProfile(language));
+    protected RemoteWebDriver createDriver(String language) {
+        FirefoxOptions options = new FirefoxOptions() //changed to recommended constructor for selenium 3.3.1
+            .setProfile(createProfile(language))
+            .setLegacy(true);
+        
+        RemoteWebDriver driver = new FirefoxDriver(options); //changed to recommended constructor for selenium 3.3.1 
+        if (!Long.valueOf(10).equals(driver.executeScript("return arguments[0]", 10))) {
+            throw new WebDriverException("This browser version is not supported due to Selenium bug 8387. See https://code.google.com/p/selenium/issues/detail?id=8387");
+        }
         return driver;
     }
 
-    /**
-     * Create a generic profile ({@link FirefoxProfile}) for use with a {@link FirefoxDriver} instance.
-     * @param language
-     * @return
-     */
-    protected FirefoxProfile createProfile(final String language) {
-        final FirefoxProfile profile = new FirefoxProfile();
+    protected FirefoxProfile createProfile(String language) {
+        FirefoxProfile profile = new FirefoxProfile();
         // native events cause "Component returned failure code: 0x80004005 (NS_ERROR_FAILURE) [nsINativeMouse.click]"
         // on Windows with multiple calls to AdfSelectOneChoice.clickItemByIndex (and others)
         profile.setEnableNativeEvents(false);
         profile.setPreference("app.update.enabled", false); // don't bother updating Firefox (takes too much time)
         profile.setPreference("browser.usedOnWindows10", true); // don't show first-time windows 10 welcome page
         profile.setPreference("intl.accept_languages", language);
+        profile.setPreference("browser.download.folderList",2);
+        profile.setPreference("browser.download.manager.showWhenStarting",false);
+        profile.setPreference("browser.helperApps.neverAsk.saveToDisk","application/pdf");
         return profile;
     }
+
 }

--- a/SeleniumTools/src/com/redheap/selenium/junit/SavePageSourceOnFailure.java
+++ b/SeleniumTools/src/com/redheap/selenium/junit/SavePageSourceOnFailure.java
@@ -16,18 +16,28 @@ import org.openqa.selenium.WebDriverException;
 
 public class SavePageSourceOnFailure extends TestWatcher {
 
+    private static final String ERRORS_SCREENSHOT_FOLDER_PROP = "errors.screenshots.folder";
+    
     private final File basedir;
     private final WebDriver driver;
 
     private static final Logger logger = Logger.getLogger(SavePageSourceOnFailure.class.getName());
 
     public SavePageSourceOnFailure(WebDriver driver) {
-        this(driver, new File("."));
+        this(driver, new File(getErrorScreenShotFolderValue()));
     }
 
     public SavePageSourceOnFailure(WebDriver driver, File basedir) {
         this.driver = driver;
         this.basedir = basedir;
+    }
+
+    private static String getErrorScreenShotFolderValue() {
+        if (System.getProperty(ERRORS_SCREENSHOT_FOLDER_PROP) == null) {
+            throw new IllegalStateException("system property " + "'"+ ERRORS_SCREENSHOT_FOLDER_PROP + "'" + 
+                                            " should contain relative path to the folder for screenshots, for example 'errorsScreenshots'");
+        }
+        return System.getProperty(ERRORS_SCREENSHOT_FOLDER_PROP);
     }
 
     @Override

--- a/SeleniumTools/src/com/redheap/selenium/junit/SavePageSourceOnFailure.java
+++ b/SeleniumTools/src/com/redheap/selenium/junit/SavePageSourceOnFailure.java
@@ -58,7 +58,7 @@ public class SavePageSourceOnFailure extends TestWatcher {
                 logger.info("*************** dumping page source " + file.getCanonicalPath());
                 try {
                     driver.switchTo().window(guid);
-                    FileUtils.writeStringToFile(file, driver.getPageSource());
+                    FileUtils.writeStringToFile(file, driver.getPageSource(), "UTF-8");
                 } catch (RuntimeException e) {
                     // ignore and continue with next window
                     e.printStackTrace();

--- a/SeleniumTools/src/com/redheap/selenium/junit/ScreenshotOnFailure.java
+++ b/SeleniumTools/src/com/redheap/selenium/junit/ScreenshotOnFailure.java
@@ -16,14 +16,16 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 
 public class ScreenshotOnFailure extends TestWatcher {
-
+    
+    private static final String ERRORS_SCREENSHOT_FOLDER_PROP = "errors.screenshots.folder";
+    
     private final File basedir;
     private final WebDriver driver;
 
     private static final Logger logger = Logger.getLogger(ScreenshotOnFailure.class.getName());
 
     public ScreenshotOnFailure(WebDriver driver) {
-        this(driver, new File("."));
+        this(driver, new File(getErrorScreenShotFolderValue ()));
     }
 
     public ScreenshotOnFailure(WebDriver driver, File basedir) {
@@ -31,6 +33,14 @@ public class ScreenshotOnFailure extends TestWatcher {
         this.basedir = basedir;
     }
 
+    private static String getErrorScreenShotFolderValue () {
+        if (System.getProperty(ERRORS_SCREENSHOT_FOLDER_PROP) == null) {
+            throw new IllegalStateException("system property " + "'"+  ERRORS_SCREENSHOT_FOLDER_PROP + "'"+ 
+                                            " should contain relative path to the folder for screenshots, for example 'errorsScreenshots'");
+        }
+        return System.getProperty(ERRORS_SCREENSHOT_FOLDER_PROP);
+    }
+    
     @Override
     protected void failed(Throwable t, Description description) {
         String oldWindow = driver.getWindowHandle();

--- a/SeleniumTools/src/com/redheap/selenium/junit/WebDriverResource.java
+++ b/SeleniumTools/src/com/redheap/selenium/junit/WebDriverResource.java
@@ -39,7 +39,7 @@ public abstract class WebDriverResource extends ExternalResource {
             logger.fine("running " + capabilities.getBrowserName() + " version " + capabilities.getVersion() + " on " +
                         capabilities.getPlatform());
         }
-        DialogManager.init(driver, 10000); // timeout of 10 seconds
+        DialogManager.init(driver, 10000, true); // timeout of 10 seconds
         driver.manage().window().maximize();
     }
 

--- a/SeleniumTools/src/com/redheap/selenium/junit/WebDriverResource.java
+++ b/SeleniumTools/src/com/redheap/selenium/junit/WebDriverResource.java
@@ -9,17 +9,16 @@ import oracle.adf.view.rich.automation.selenium.DialogManager;
 import org.junit.rules.ExternalResource;
 
 import org.openqa.selenium.Capabilities;
-import org.openqa.selenium.Dimension;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
 public abstract class WebDriverResource extends ExternalResource {
-
-    private static final Logger logger = Logger.getLogger(WebDriverResource.class.getName());
 
     private RemoteWebDriver driver;
     private final int width;
     private final int height;
     private final Locale locale;
+
+    private static final Logger logger = Logger.getLogger(WebDriverResource.class.getName());
 
     public WebDriverResource() {
         this(1920, 1200, Locale.US);
@@ -41,7 +40,7 @@ public abstract class WebDriverResource extends ExternalResource {
                         capabilities.getPlatform());
         }
         DialogManager.init(driver, 10000); // timeout of 10 seconds
-        driver.manage().window().setSize(new Dimension(width, height));
+        driver.manage().window().maximize();
     }
 
     protected abstract RemoteWebDriver createDriver(String language);

--- a/SeleniumTools/src/com/redheap/selenium/output/FileOutputType.java
+++ b/SeleniumTools/src/com/redheap/selenium/output/FileOutputType.java
@@ -22,7 +22,7 @@ public class FileOutputType implements OutputType<File> {
     @Override
     public File convertFromBase64Png(String base64Png) {
         try {
-            IOUtils.copy(new Base64InputStream(IOUtils.toInputStream(base64Png)), new FileOutputStream(file));
+            IOUtils.copy(new Base64InputStream(IOUtils.toInputStream(base64Png, "UTF-8" )), new FileOutputStream(file));
         } catch (IOException e) {
             throw new WebDriverException(e);
         }

--- a/SeleniumTools/src/com/redheap/selenium/page/DeclarativeComponentFragment.java
+++ b/SeleniumTools/src/com/redheap/selenium/page/DeclarativeComponentFragment.java
@@ -3,6 +3,7 @@ package com.redheap.selenium.page;
 import com.redheap.selenium.component.AdfComponent;
 import com.redheap.selenium.component.AdfDynamicDeclarativeComponent;
 import com.redheap.selenium.component.AdfRegion;
+import com.redheap.selenium.component.uix.UixInclude;
 import com.redheap.selenium.domain.PageMessageWrapper;
 
 import oracle.adf.view.rich.automation.selenium.DialogManager;
@@ -13,9 +14,9 @@ import org.openqa.selenium.WebDriverException;
 
 public class DeclarativeComponentFragment /*extends BaseObject*/ {
 
-    private final AdfDynamicDeclarativeComponent dclr;
+    private final UixInclude dclr;
 
-    public DeclarativeComponentFragment(AdfDynamicDeclarativeComponent dclr) {
+    public DeclarativeComponentFragment(UixInclude dclr) {
         this.dclr = dclr;
     }
 
@@ -28,7 +29,7 @@ public class DeclarativeComponentFragment /*extends BaseObject*/ {
     }
 
 
-    protected AdfDynamicDeclarativeComponent findDeclarativeComponent() {
+    protected UixInclude findDeclarativeComponent() {
         return dclr;
     }
 

--- a/SeleniumTools/src/com/redheap/selenium/page/DeclarativeComponentFragment.java
+++ b/SeleniumTools/src/com/redheap/selenium/page/DeclarativeComponentFragment.java
@@ -1,0 +1,44 @@
+package com.redheap.selenium.page;
+
+import com.redheap.selenium.component.AdfComponent;
+import com.redheap.selenium.component.AdfDeclarativeComponent;
+import com.redheap.selenium.component.AdfRegion;
+import com.redheap.selenium.domain.PageMessageWrapper;
+
+import oracle.adf.view.rich.automation.selenium.DialogManager;
+
+import org.apache.commons.lang3.reflect.ConstructorUtils;
+
+import org.openqa.selenium.WebDriverException;
+
+public class DeclarativeComponentFragment /*extends BaseObject*/ {
+
+    private final AdfDeclarativeComponent dclr;
+
+    public DeclarativeComponentFragment(AdfDeclarativeComponent dclr) {
+        this.dclr = dclr;
+    }
+
+    protected <P extends DeclarativeComponentFragment> P getDclrContent(Class<? extends P> cls) {
+        try {
+            return ConstructorUtils.invokeConstructor(cls, dclr);
+        } catch (Exception e) {
+            throw new WebDriverException(e.getCause() != null ? e.getCause() : e);
+        }
+    }
+
+
+    protected AdfDeclarativeComponent findDeclarativeComponent() {
+        return dclr;
+    }
+
+    protected <T extends AdfComponent> T findAdfComponent(String relativeClientId) {
+        return dclr.findAdfComponent(relativeClientId);
+    }
+    
+    protected <T extends AdfComponent> T findAdfComponentByLocator(String relativeLocator) {
+        return dclr.findAdfComponentByLocator(relativeLocator);
+    }
+
+}
+

--- a/SeleniumTools/src/com/redheap/selenium/page/DeclarativeComponentFragment.java
+++ b/SeleniumTools/src/com/redheap/selenium/page/DeclarativeComponentFragment.java
@@ -1,7 +1,7 @@
 package com.redheap.selenium.page;
 
 import com.redheap.selenium.component.AdfComponent;
-import com.redheap.selenium.component.AdfDeclarativeComponent;
+import com.redheap.selenium.component.AdfDynamicDeclarativeComponent;
 import com.redheap.selenium.component.AdfRegion;
 import com.redheap.selenium.domain.PageMessageWrapper;
 
@@ -13,9 +13,9 @@ import org.openqa.selenium.WebDriverException;
 
 public class DeclarativeComponentFragment /*extends BaseObject*/ {
 
-    private final AdfDeclarativeComponent dclr;
+    private final AdfDynamicDeclarativeComponent dclr;
 
-    public DeclarativeComponentFragment(AdfDeclarativeComponent dclr) {
+    public DeclarativeComponentFragment(AdfDynamicDeclarativeComponent dclr) {
         this.dclr = dclr;
     }
 
@@ -28,7 +28,7 @@ public class DeclarativeComponentFragment /*extends BaseObject*/ {
     }
 
 
-    protected AdfDeclarativeComponent findDeclarativeComponent() {
+    protected AdfDynamicDeclarativeComponent findDeclarativeComponent() {
         return dclr;
     }
 

--- a/SeleniumTools/src/com/redheap/selenium/page/Page.java
+++ b/SeleniumTools/src/com/redheap/selenium/page/Page.java
@@ -34,7 +34,11 @@ public abstract class Page /*implements TakesScreenshot*/ {
 
     private static final String JS_GET_REGIONS =
         "{ids=[]; AdfPage.PAGE.getComponentsByType('oracle.adf.RichRegion').forEach(function(r){ids.push(r.getClientId())}); return ids}";
-    private static final String JS_GET_DOCID = "return AdfPage.PAGE.getDocumentClientId()";
+    private static final String JS_GET_DOCID = "return AdfPage.PAGE.getDocumentClientId()"; // Here is used Internal function to retrieve the document component's client ID
+                                                                                            // ��. oracle.adfinternal.view.js.laf.dhtml.rich.AdfDhtmlPage.getDocumentClientId()
+                                                                                            // https://docs.oracle.com/middleware/1221/adf/api-reference-javascript-faces/oracle/adfinternal/view/js/laf/dhtml/rich/AdfDhtmlPage.html
+                                                                                            //
+    
     private static final Logger logger = Logger.getLogger(Page.class.getName());
 
     public Page(WebDriver driver) {
@@ -88,6 +92,10 @@ public abstract class Page /*implements TakesScreenshot*/ {
 
     protected <T extends AdfComponent> T findAdfComponent(String relativeClientId) {
         return findDocument().findAdfComponent(relativeClientId);
+    }
+
+    protected <T extends AdfComponent> T findAdfComponentByLocator(String relativeClientId) {
+        return findDocument().findAdfComponentByLocator(relativeClientId);
     }
 
     public <X extends Object> X getScreenshotAs(OutputType<X> target) throws WebDriverException {

--- a/libs/Adf-richclient-automation-lite.library
+++ b/libs/Adf-richclient-automation-lite.library
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<library name="Adf-richclient-automation-lite" id="" xmlns="http://xmlns.oracle.com/jdeveloper/1013/manifest-libraries">
+  <description/>
+  <classpath>adf-richclient-automation-lite.jar</classpath>
+</library>

--- a/libs/Selenium Libs-3-3-1.library
+++ b/libs/Selenium Libs-3-3-1.library
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<library name="Selenium Libs-3-3-1" id="oracle..selenium-libs-3-3-1" deployed="true" xmlns="http://xmlns.oracle.com/jdeveloper/1013/manifest-libraries">
+  <description/>
+  <classpath>selenium-java-3.3.1/client-combined-3.3.1-nodeps.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/cglib-nodep-3.2.4.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/commons-codec-1.10.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/commons-exec-1.3.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/commons-io-2.5.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/commons-lang3-3.5.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/commons-logging-1.2.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/cssparser-0.9.21.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/gson-2.8.0.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/guava-21.0.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/hamcrest-core-1.3.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/hamcrest-library-1.3.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/htmlunit-2.24.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/htmlunit-core-js-2.23.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/htmlunit-driver-2.24.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/httpclient-4.5.2.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/httpcore-4.4.4.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/httpmime-4.5.2.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/javax.servlet-api-3.1.0.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/jetty-io-9.4.1.v20170120.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/jetty-util-9.4.1.v20170120.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/jna-4.1.0.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/jna-platform-4.1.0.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/junit-4.12.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/neko-htmlunit-2.24.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/phantomjsdriver-1.4.0.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/sac-1.3.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/serializer-2.7.2.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/websocket-api-9.2.20.v20161216.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/websocket-client-9.2.20.v20161216.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/websocket-common-9.2.20.v20161216.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/xalan-2.7.2.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/xercesImpl-2.11.0.jar</classpath>
+  <classpath>selenium-java-3.3.1/lib/xml-apis-1.4.01.jar</classpath>
+</library>

--- a/xslt/declarativeComponent.jspx-to-Page-Objects.xsl
+++ b/xslt/declarativeComponent.jspx-to-Page-Objects.xsl
@@ -1,0 +1,251 @@
+<xsl:stylesheet version="1.0" 
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:jsp="http://java.sun.com/JSP/Page"
+	xmlns:af="http://xmlns.oracle.com/adf/faces/rich"
+	xmlns:f="http://java.sun.com/jsf/core"
+	xmlns:h="http://java.sun.com/jsf/html"
+	xmlns:trh="http://myfaces.apache.org/trinidad/html"
+    xmlns:c="http://java.sun.com/jsp/jstl/core" 
+	xmlns:dvt="http://xmlns.oracle.com/dss/adf/faces"
+    xmlns:wf="http://xmlns.oracle.com/bpel/workflow/workflow-taglib.tld"
+    xmlns:wlc="http://xmlns.oracle.com/bpel/workflow/worklist"
+	>
+	
+<xsl:output method="text"/>
+<xsl:strip-space elements="*" />
+
+<xsl:variable name="vLower" select="'abcdefghijklmnopqrstuvwxyz'"/>
+<xsl:variable name="vUpper" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'"/>
+
+<xsl:template match="/">
+/*
+ * XSLT Generated 
+ * This is Page Object Model for the tested ADF Page.
+ * The model includes java code for those of Adf Faces Tag which are listed xsl:template match=. You can change this list according to your needs and re-generate code for this class.
+ * Generated code includes: 
+ *	- String constant with ADF component AbsoluteId value. This constant then is used to locate component by corresponding findAdfComponent() method of SeleniumTools library.
+ *	- find-method which returm object instance representing ADF component.
+ * См.
+ * https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/oracle/adf/view/js/base/AdfPage.html#findComponentByAbsoluteId_String_
+ * https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/oracle/adf/view/js/component/AdfUIComponent.html#findComponent_String__Boolean_
+*/
+<!--
+Here set the component type starting processing from.
+For example, 
+1) set select = "//af:popup" in order to process child components of every popup not regarding to it hierarchy
+2) set select = "node()" in order to process from the top of document
+3) set select = "//af:table[@id='t8']" in order to process child components of particular table with id=t8
+  -->
+
+/*
+ * Methods to locate and interract with components in the section f:facet name="first"
+*/  
+<xsl:apply-templates select = "//f:facet[@name='first']"/>
+
+
+</xsl:template>
+
+<!--
+This template is used to generate part of Page Objects Model representing Adf Components inside Naming Containers.
+
+This template generates 
+a) the statement for AbsoluteId of Adf Component only: final static String _id ="NC1id:NC2:ComponentId value"
+b) the statement for general implementation of find-Method. Implementation of find-Method bases on calling com.redheap.selenium.component.AdfComponent.findAdfComponent(_id).
+ -->
+
+<xsl:template match=   "af:button	|
+						af:column	|
+						af:commandButton	|
+						af:commandLink	|
+						af:commandMenuItem	|
+						af:commandNavigationItem	|
+						af:commandToolbarButton	|
+						af:declarativeComponent |
+						af:dialog	|
+						af:inlineFrame	|
+						af:inputComboboxListOfValues	|
+						af:inputDate	|
+						af:inputFile	|
+						af:inputListOfValues	|
+						af:inputNumberSpinbox	|
+						af:inputText	|
+						af:link	|
+						af:listView |
+						af:menu	|
+						af:outputFormatted	|
+						af:outputText	|
+						af:popup	|
+						af:panelGridLayout |
+						af:region |
+						af:selectBooleanCheckbox	|
+						af:selectBooleanRadio	|
+						af:selectManyChoice	|
+						af:selectOneChoice	|
+						af:selectOneListbox	|
+						af:selectOneRadio	|
+						af:showDetailItem |
+						af:table |
+						af:toolbar |
+						dvt:schedulingGantt |
+						dvt:timeAxis">
+
+<xsl:variable name="vAdfTagName" select="local-name()"/>
+<xsl:variable name="vAdfTagNameCamel" select="concat(translate(substring($vAdfTagName,1,1), $vLower, $vUpper), substring($vAdfTagName,2))"/>
+<xsl:variable name="vAdfComponentClassName" select="concat('Adf',$vAdfTagNameCamel)"/>
+
+<xsl:variable name="vAdfElementName" >
+   <xsl:choose>
+     <xsl:when test="substring-before(substring-after(@value,'#{demoLOV.'),'}') != '' ">
+        <xsl:value-of select="substring-before(substring-after(@value,'#{demoLOV.'),'}')"/>
+     </xsl:when>
+     <xsl:otherwise>
+       <xsl:value-of select="concat('_',@id)"/>
+     </xsl:otherwise>
+   </xsl:choose>
+</xsl:variable> 
+
+<xsl:variable name="vAdfElementNameLow" select ="concat(translate(substring($vAdfElementName,1,1), $vUpper, $vLower), substring($vAdfElementName,2))"/>
+<xsl:variable name="vAdfElementNameUpper" select ="concat(translate(substring($vAdfElementName,1,1), $vLower, $vUpper), substring($vAdfElementName,2))"/>
+
+<xsl:variable name="vIdStringName" select ="concat($vAdfElementNameLow,$vAdfTagNameCamel)"/>
+<xsl:variable name="vAdfFindMethodName" select ="concat('find',$vAdfElementNameUpper)"/>
+static final String <xsl:value-of select = "$vIdStringName" /> = "<xsl:apply-templates 	select="ancestor::*[self::af:breadCrumbs |
+																										   self::af:calendar |
+																										   self::af:carousel |
+                                                                                                           self::af:declarativeComponent |
+																										   self::af:iterator |
+																										   self::af:listView |
+																										   self::af:navigationPane | 
+																										   self::af:panelCollection | 
+																										   self::af:query | 
+																										   self::af:quickQuery | 
+																										   self::af:region | 
+																										   self::af:pageTemplate | 
+																										   self::af:subform | 
+																										   self::af:table | 
+																										   self::af:train |
+																										   self::af:trainButtonBar |
+                                                                                                           self::af:treeTable | 
+                                                                                                           self::af:tree |
+																										   self::af:subform |
+																										   self::dvt:schedulingGantt]" 				
+																						mode="collectAbsoluteId"/><xsl:value-of select="@id"/>";
+
+public <xsl:value-of select = "$vAdfComponentClassName"/> <xsl:text> </xsl:text> <xsl:value-of select = "$vAdfFindMethodName"/> () {
+	return findAdfComponent(<xsl:value-of select = "$vIdStringName" />);
+}
+	<xsl:choose>
+		<!--Special transforming for af:region and other ADF Faces tags that locate Fragments -->
+		<xsl:when test="name() = 'af:region'">
+public 'Customize here fragment's class name'Fragment get<xsl:value-of select="$vIdStringName"/>Content () {
+    //Add here code for fragment's initialization action on you page. Like: findOrderListTab().click();
+    return new 'Insert here call of appropriate fragment constructor'(<xsl:value-of select="$vAdfFindMethodName"/>());
+}
+		</xsl:when>
+		
+		<xsl:when test="name() = 'af:declarativeComponent'">
+public 'Customize here fragment's class name'Fragment get<xsl:value-of select="$vIdStringName"/>Content () {
+    //Add here code for fragment's initialization action on you page. Like: findOrderListTab().click();
+    return new 'Insert here call of appropriate fragment constructor'(<xsl:value-of select="$vAdfFindMethodName"/>());
+}
+		</xsl:when>		
+		<!--Then transforming for all others ADF Faces tags-->
+		<xsl:otherwise>
+			<xsl:choose>
+				<!--Special transforming for af:table, af:listView, af:carousel -->
+				<xsl:when test="name() = 'af:listView' or 
+								name() = 'af:table' or
+								name() = 'af:carousel'">
+				<!--For all non-column-childes of af:table, af:listView, af:carousel, in other words Direct Known Subclasses of ADFUIIterator applying specific template which generates get-Methods-->
+/*
+ * Methods to locate stamped-components
+*/
+				<xsl:apply-templates select="node()" mode="stampedComponents"/>
+				<!--For all column-childes of af:table, af:listView, af:carousel, applying general template which generates and generate find-Methods. And see the next comment below -->
+/*
+ * Methods to locate column-components itself
+*/
+				<xsl:apply-templates select="af:column"/>
+				</xsl:when>
+				<!--For childes of columns do nothing, because childes of columns are actually childes of af:table, af:listView, af:carousel-->
+				<xsl:when test="name() = 'af:column'">
+				<!--Do nothing here and stop processing the on the column itself-->
+				</xsl:when>
+				<!--Then transforming for the rest of ADF Faces tags-->
+				<xsl:otherwise>
+				<!--Applying general template which generate find-Methods-->
+					<xsl:apply-templates select="node()"/>
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:otherwise>
+	</xsl:choose>
+</xsl:template>
+
+<!--
+This template is used to generate part of Page Objects Model representing Adf Components stamped in the rows of af:table, af:listView, af:carousel, in other words Direct Known Subclasses of ADFUIIterator. See https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/toc.htm
+
+This is the specific template of one above.
+This one generates the statement for ComponentId of Adf Component only: final static String _id ="id-attribute value"
+The find-Method is not generated instead get-Methods are generated for id-string-properties.
+ -->
+
+<xsl:template mode ="stampedComponents" 
+			  match=   "af:button	|
+						af:commandButton	|
+						af:commandLink	|
+						af:commandMenuItem	|
+						af:commandNavigationItem	|
+						af:commandToolbarButton	|
+						af:inputComboboxListOfValues	|
+						af:inputDate	|
+						af:inputFile	|
+						af:inputListOfValues	|
+						af:inputNumberSpinbox	|
+						af:inputText	|
+						af:link	|
+						af:menu	|
+						af:outputFormatted	|
+						af:outputText	|
+						af:selectBooleanCheckbox	|
+						af:selectBooleanRadio	|
+						af:selectManyChoice	|
+						af:selectOneChoice	|
+						af:selectOneListbox	|
+						af:selectOneRadio	|
+						af:showDetailItem">
+
+<xsl:variable name="vAdfTagName" select="local-name()"/>
+<xsl:variable name="vAdfTagNameCamel" select="concat(translate(substring($vAdfTagName,1,1), $vLower, $vUpper), substring($vAdfTagName,2))"/>
+
+<xsl:variable name="vAdfElementName" >
+   <xsl:choose>
+     <xsl:when test="substring-before(substring-after(@value,'#{demoLOV.'),'}') != '' ">
+        <xsl:value-of select="substring-before(substring-after(@value,'#{demoLOV.'),'}')"/>
+     </xsl:when>
+     <xsl:otherwise>
+       <xsl:value-of select="concat('_',@id)"/>
+     </xsl:otherwise>
+   </xsl:choose>
+</xsl:variable> 
+
+<xsl:variable name="vAdfElementNameLow" select ="concat(translate(substring($vAdfElementName,1,1), $vUpper, $vLower), substring($vAdfElementName,2))"/>
+
+<xsl:variable name="vIdStringName" select ="concat($vAdfElementNameLow,$vAdfTagNameCamel,'Id')"/>
+static final String <xsl:value-of select = "$vIdStringName" /> = "<xsl:value-of select="@id"/>";
+public static final String get<xsl:value-of select = "$vIdStringName" />() {
+    return <xsl:value-of select = "$vIdStringName" />;
+}
+<xsl:apply-templates select = "node()" mode ="stampedComponents"/>
+</xsl:template>
+
+<!--This Template for collecting id-attribute values from selected ancestor's - naming container's of processed node-->
+<!--
+Note, that according to XSL specification <xsl:template match= /> could accept only child and attributes axes elements in pattern.
+That is why all needed naming container's should be selected in <xsl:apply-templates> statement and here in template itself match="*" is used.
+--> 
+<xsl:template 	match="*"				mode="collectAbsoluteId">
+	<xsl:value-of select="@id"/>
+	<xsl:text>:</xsl:text>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/xslt/dynamicDeclarativeComponentExample.jsff-to-Page-Objects.xsl
+++ b/xslt/dynamicDeclarativeComponentExample.jsff-to-Page-Objects.xsl
@@ -1,0 +1,271 @@
+<xsl:stylesheet version="1.0" 
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:jsp="http://java.sun.com/JSP/Page"
+	xmlns:af="http://xmlns.oracle.com/adf/faces/rich"
+	xmlns:f="http://java.sun.com/jsf/core"
+	xmlns:h="http://java.sun.com/jsf/html"
+	xmlns:trh="http://myfaces.apache.org/trinidad/html"
+    xmlns:c="http://java.sun.com/jsp/jstl/core" 
+	xmlns:dvt="http://xmlns.oracle.com/dss/adf/faces"
+    xmlns:wf="http://xmlns.oracle.com/bpel/workflow/workflow-taglib.tld"
+    xmlns:wlc="http://xmlns.oracle.com/bpel/workflow/worklist"
+	>
+	
+<xsl:output method="text"/>
+<xsl:strip-space elements="*" />
+
+<xsl:variable name="vLower" select="'abcdefghijklmnopqrstuvwxyz'"/>
+<xsl:variable name="vUpper" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'"/>
+
+<xsl:template match="/">
+/*
+ * XSLT Generated 
+ * This is Page Object Model for the tested ADF Page.
+ * The model includes java code for those of Adf Faces Tag which are listed xsl:template match=. You can change this list according to your needs and re-generate code for this class.
+ * Generated code includes: 
+ *	- String constant with ADF component AbsoluteId value. This constant then is used to locate component by corresponding findAdfComponent() method of SeleniumTools library.
+ *	- find-method which returm object instance representing ADF component.
+ * См.
+ * https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/oracle/adf/view/js/base/AdfPage.html#findComponentByAbsoluteId_String_
+ * https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/oracle/adf/view/js/component/AdfUIComponent.html#findComponent_String__Boolean_
+*/
+<!--
+Here set the component type starting processing from.
+For example, 
+1) set select = "//af:popup" in order to process child components of every popup not regarding to it hierarchy
+2) set select = "node()" in order to process from the top of document
+3) set select = "//af:table[@id='t8']" in order to process child components of particular table with id=t8
+  -->
+
+/*
+ * Methods to locate and interract with inner components of DynamicDeclarativeComponentExample
+*/  
+<xsl:apply-templates select = "//af:componentDef[@componentVar='comp']"/>
+
+
+</xsl:template>
+
+<!--
+This template is used to generate part of Page Objects Model representing Adf Components inside Naming Containers.
+
+This template generates 
+a) the statement for AbsoluteId of Adf Component only: final static String _id ="NC1id:NC2:ComponentId value"
+b) the statement for general implementation of find-Method. Implementation of find-Method bases on calling com.redheap.selenium.component.AdfComponent.findAdfComponent(_id).
+ -->
+
+<xsl:template match=   "af:button	|
+						af:column	|
+						af:commandButton	|
+						af:commandLink	|
+						af:commandMenuItem	|
+						af:commandNavigationItem	|
+						af:commandToolbarButton	|
+						af:declarativeComponent |
+						af:dialog	|
+						af:inlineFrame	|
+						af:inputComboboxListOfValues	|
+						af:inputDate	|
+						af:inputFile	|
+						af:inputListOfValues	|
+						af:inputNumberSpinbox	|
+						af:inputText	|
+						af:iterator |
+						af:link	|
+						af:listView |
+						af:menu	|
+						af:outputFormatted	|
+						af:outputText	|
+						af:popup	|
+						af:panelGridLayout |
+						af:region |
+						af:selectBooleanCheckbox	|
+						af:selectBooleanRadio	|
+						af:selectManyChoice	|
+						af:selectOneChoice	|
+						af:selectOneListbox	|
+						af:selectOneRadio	|
+						af:showDetailItem |
+						af:table |
+						af:toolbar |
+						dvt:schedulingGantt |
+						dvt:timeAxis">
+
+<xsl:variable name="vAdfTagName" select="local-name()"/>
+<xsl:variable name="vAdfTagNameCamel" select="concat(translate(substring($vAdfTagName,1,1), $vLower, $vUpper), substring($vAdfTagName,2))"/>
+<xsl:variable name="vAdfComponentClassName" select="concat('Adf',$vAdfTagNameCamel)"/>
+
+<xsl:variable name="vAdfElementName" >
+   <xsl:choose>
+     <xsl:when test="substring-before(substring-after(@value,'#{demoLOV.'),'}') != '' ">
+        <xsl:value-of select="substring-before(substring-after(@value,'#{demoLOV.'),'}')"/>
+     </xsl:when>
+     <xsl:otherwise>
+       <xsl:value-of select="concat('_',@id)"/>
+     </xsl:otherwise>
+   </xsl:choose>
+</xsl:variable> 
+
+<xsl:variable name="vAdfElementNameLow" select ="concat(translate(substring($vAdfElementName,1,1), $vUpper, $vLower), substring($vAdfElementName,2))"/>
+<xsl:variable name="vAdfElementNameUpper" select ="concat(translate(substring($vAdfElementName,1,1), $vLower, $vUpper), substring($vAdfElementName,2))"/>
+
+<xsl:variable name="vIdStringName" select ="concat($vAdfElementNameLow,$vAdfTagNameCamel)"/>
+<xsl:variable name="vAdfFindMethodName" select ="concat('find',$vAdfElementNameUpper)"/>
+static final String <xsl:value-of select = "$vIdStringName" /> = "<xsl:apply-templates 	select="ancestor::*[self::af:breadCrumbs |
+																										   self::af:calendar |
+																										   self::af:carousel |
+                                                                                                           self::af:declarativeComponent |
+																										   self::af:iterator |
+																										   self::af:listView |
+																										   self::af:navigationPane | 
+																										   self::af:panelCollection | 
+																										   self::af:query | 
+																										   self::af:quickQuery | 
+																										   self::af:region | 
+																										   self::af:pageTemplate | 
+																										   self::af:subform | 
+																										   self::af:table | 
+																										   self::af:train |
+																										   self::af:trainButtonBar |
+                                                                                                           self::af:treeTable | 
+                                                                                                           self::af:tree |
+																										   self::af:subform |
+																										   self::dvt:schedulingGantt]" 				
+																						mode="collectAbsoluteId"/><xsl:value-of select="@id"/>";
+	<xsl:choose>
+		<!--Special transforming for af:iterator because af:iterator itself is never rendered into client component -->
+		<xsl:when test="name() = 'af:iterator'">
+public static final String get<xsl:value-of select = "$vIdStringName" />() {
+    return <xsl:value-of select = "$vIdStringName" />;
+}
+/*
+ * Methods to locate stamped-components of af:iterator.
+ * For stamped-components of af:iterator is applied general template which generates AbsoluteId and general find-Methods
+ * You need manually change them into componentId and find-by-index methods by concatinanting iterator absoluteId, index, componentId.
+ * Also Mention situation when iterators are hierarhical 
+*/	
+		</xsl:when>
+		<!--Applying general template which generate find-Methods-->
+		<xsl:otherwise>	
+public <xsl:value-of select = "$vAdfComponentClassName"/> <xsl:text> </xsl:text> <xsl:value-of select = "$vAdfFindMethodName"/> () {
+	return findAdfComponent(<xsl:value-of select = "$vIdStringName" />);
+}
+		</xsl:otherwise>
+	</xsl:choose>
+	
+	<xsl:choose>
+		<!--Special transforming for af:region and other ADF Faces tags that locate Fragments -->
+		<xsl:when test="name() = 'af:region'">
+public 'Customize here fragment's class name'Fragment get<xsl:value-of select="$vIdStringName"/>Content () {
+    //Add here code for fragment's initialization action on you page. Like: findOrderListTab().click();
+    return new 'Insert here call of appropriate fragment constructor'(<xsl:value-of select="$vAdfFindMethodName"/>());
+}
+		</xsl:when>
+		
+		<xsl:when test="name() = 'af:declarativeComponent'">
+public 'Customize here fragment's class name'Fragment get<xsl:value-of select="$vIdStringName"/>Content () {
+    //Add here code for fragment's initialization action on you page. Like: findOrderListTab().click();
+    return new 'Insert here call of appropriate fragment constructor'(<xsl:value-of select="$vAdfFindMethodName"/>());
+}
+		</xsl:when>
+						
+		<!--Then transforming for all others ADF Faces tags-->
+		<xsl:otherwise>
+			<xsl:choose>
+				<!--Special transforming for af:table, af:listView, af:carousel -->
+
+				<xsl:when test="name() = 'af:listView' or 
+								name() = 'af:table' or
+								name() = 'af:carousel'">
+				<!--For all non-column-childes of af:table, af:listView, af:carousel, in other words Direct Known Subclasses of ADFUIIterator applying specific template which generates get-Methods-->
+/*
+ * Methods to locate stamped-components of  <xsl:value-of select = "name()"/>
+*/
+
+				<!--For all column-childes of af:table, af:listView, af:carousel, applying general template which generates and generate find-Methods. And see the next comment below -->
+/*
+ * Methods to locate column-components of <xsl:value-of select = "name()"/> itself
+*/
+				<xsl:apply-templates select="af:column"/>
+				</xsl:when>
+				<!--For childes of columns do nothing, because childes of columns are actually childes of af:table, af:listView, af:carousel-->
+				<xsl:when test="name() = 'af:column'">
+				<!--Do nothing here and stop processing on the column itself-->
+				</xsl:when>
+				<!--Then transforming for the rest of ADF Faces tags-->
+				<xsl:otherwise>
+				<!--Applying general template which generate find-Methods-->
+					<xsl:apply-templates select="node()"/>
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:otherwise>
+	</xsl:choose>
+</xsl:template>
+
+<!--
+This template is used to generate part of Page Objects Model representing Adf Components stamped in the rows of af:table, af:listView, af:carousel, in other words Direct Known Subclasses of ADFUIIterator. See https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/toc.htm
+
+This is the specific template of one above.
+This one generates the statement for ComponentId of Adf Component only: final static String _id ="id-attribute value"
+The find-Method is not generated instead get-Methods are generated for id-string-properties.
+ -->
+
+<xsl:template mode ="stampedComponents" 
+			  match=   "af:button	|
+						af:commandButton	|
+						af:commandLink	|
+						af:commandMenuItem	|
+						af:commandNavigationItem	|
+						af:commandToolbarButton	|
+						af:inputComboboxListOfValues	|
+						af:inputDate	|
+						af:inputFile	|
+						af:inputListOfValues	|
+						af:inputNumberSpinbox	|
+						af:inputText	|
+						af:link	|
+						af:menu	|
+						af:outputFormatted	|
+						af:outputText	|
+						af:selectBooleanCheckbox	|
+						af:selectBooleanRadio	|
+						af:selectManyChoice	|
+						af:selectOneChoice	|
+						af:selectOneListbox	|
+						af:selectOneRadio	|
+						af:showDetailItem">
+
+<xsl:variable name="vAdfTagName" select="local-name()"/>
+<xsl:variable name="vAdfTagNameCamel" select="concat(translate(substring($vAdfTagName,1,1), $vLower, $vUpper), substring($vAdfTagName,2))"/>
+
+<xsl:variable name="vAdfElementName" >
+   <xsl:choose>
+     <xsl:when test="substring-before(substring-after(@value,'#{demoLOV.'),'}') != '' ">
+        <xsl:value-of select="substring-before(substring-after(@value,'#{demoLOV.'),'}')"/>
+     </xsl:when>
+     <xsl:otherwise>
+       <xsl:value-of select="concat('_',@id)"/>
+     </xsl:otherwise>
+   </xsl:choose>
+</xsl:variable> 
+
+<xsl:variable name="vAdfElementNameLow" select ="concat(translate(substring($vAdfElementName,1,1), $vUpper, $vLower), substring($vAdfElementName,2))"/>
+
+<xsl:variable name="vIdStringName" select ="concat($vAdfElementNameLow,$vAdfTagNameCamel,'Id')"/>
+static final String <xsl:value-of select = "$vIdStringName" /> = "<xsl:value-of select="@id"/>";
+public static final String get<xsl:value-of select = "$vIdStringName" />() {
+    return <xsl:value-of select = "$vIdStringName" />;
+}
+<xsl:apply-templates select = "node()" mode ="stampedComponents"/>
+</xsl:template>
+
+<!--This Template for collecting id-attribute values from selected ancestor's - naming container's of processed node-->
+<!--
+Note, that according to XSL specification <xsl:template match= /> could accept only child and attributes axes elements in pattern.
+That is why all needed naming container's should be selected in <xsl:apply-templates> statement and here in template itself match="*" is used.
+--> 
+<xsl:template 	match="*"				mode="collectAbsoluteId">
+	<xsl:value-of select="@id"/>
+	<xsl:text>:</xsl:text>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/xslt/inputComboboxListOfValues.jspx-to-Page-Objects.xsl
+++ b/xslt/inputComboboxListOfValues.jspx-to-Page-Objects.xsl
@@ -1,0 +1,193 @@
+<xsl:stylesheet version="1.0" 
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:jsp="http://java.sun.com/JSP/Page"
+	xmlns:af="http://xmlns.oracle.com/adf/faces/rich"
+	xmlns:f="http://java.sun.com/jsf/core"
+	xmlns:h="http://java.sun.com/jsf/html"
+	xmlns:trh="http://myfaces.apache.org/trinidad/html"
+    xmlns:c="http://java.sun.com/jsp/jstl/core" 
+	xmlns:dvt="http://xmlns.oracle.com/dss/adf/faces"
+    xmlns:wf="http://xmlns.oracle.com/bpel/workflow/workflow-taglib.tld"
+    xmlns:wlc="http://xmlns.oracle.com/bpel/workflow/worklist"
+	>
+	
+<xsl:output method="text"/>
+<xsl:strip-space elements="*" />
+
+<xsl:variable name="vLower" select="'abcdefghijklmnopqrstuvwxyz'"/>
+<xsl:variable name="vUpper" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'"/>
+
+<xsl:template match="/">
+/*
+ * XSLT Generated 
+ * This is Page Object Model for the tested ADF Page.
+ * The model includes java code for those of Adf Faces Tag which are listed xsl:template match=. You can change this list according to your needs and re-generate code for this class.
+ * Generated code includes: 
+ *	- String constant with ADF component AbsoluteId value. This constant then is used to locate component by corresponding findAdfComponent() method of SeleniumTools library.
+ *	- find-method which returm object instance representing ADF component.
+ * См.
+ * https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/oracle/adf/view/js/base/AdfPage.html#findComponentByAbsoluteId_String_
+ * https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/oracle/adf/view/js/component/AdfUIComponent.html#findComponent_String__Boolean_
+*/
+<!--
+Here set the component type starting processing from.
+For example, 
+1) set select = "//af:popup" in order to process child components of every popup not regarding to it hierarchy
+2) set select = "node()" in order to process from the top of document
+3) set select = "//af:table[@id='t8']" in order to process child components of particular table with id=t8
+  -->
+
+/*
+ * Methods to locate and interract with components in section f:facet name="seriesComponent"
+*/  
+<xsl:apply-templates select = "//f:facet[@name='seriesComponent']"/>
+
+/*
+ * Methods to locate and interract with components in section f:facet name="seriesBelow"
+*/  
+<xsl:apply-templates select = "//f:facet[@name='seriesBelow']"/>
+
+</xsl:template>
+
+<!--
+This template is used to generate part of Page Objects Model representing Adf Components inside Naming Containers.
+
+This template generates 
+a) the statement for AbsoluteId of Adf Component only: final static String _id ="NC1id:NC2:ComponentId value"
+b) the statement for general implementation of find-Method. Implementation of find-Method bases on calling com.redheap.selenium.component.AdfComponent.findAdfComponent(_id).
+ -->
+
+<xsl:template match=   "af:inputComboboxListOfValues">
+
+<xsl:variable name="vAdfTagName" select="local-name()"/>
+<xsl:variable name="vAdfTagNameCamel" select="concat(translate(substring($vAdfTagName,1,1), $vLower, $vUpper), substring($vAdfTagName,2))"/>
+<xsl:variable name="vAdfComponentClassName" select="concat('Adf',$vAdfTagNameCamel)"/>
+
+<xsl:variable name="vAdfElementName" >
+   <xsl:choose>
+     <xsl:when test="substring-before(substring-after(@value,'#{bindings.'),'.') != '' ">
+        <xsl:value-of select="substring-before(substring-after(@value,'#{bindings.'),'.')"/>
+     </xsl:when>
+     <xsl:otherwise>
+       <xsl:value-of select="concat('_',@id)"/>
+     </xsl:otherwise>
+   </xsl:choose>
+</xsl:variable> 
+
+<xsl:variable name="vAdfElementNameLow" select ="concat(translate(substring($vAdfElementName,1,1), $vUpper, $vLower), substring($vAdfElementName,2))"/>
+<xsl:variable name="vAdfElementNameUpper" select ="concat(translate(substring($vAdfElementName,1,1), $vLower, $vUpper), substring($vAdfElementName,2))"/>
+
+<xsl:variable name="vIdStringName" select ="concat($vAdfElementNameLow,$vAdfTagNameCamel)"/>
+<xsl:variable name="vAdfFindMethodName" select ="concat('find',$vAdfElementNameUpper)"/>
+static final String <xsl:value-of select = "$vIdStringName" /> = "<xsl:apply-templates 	select="ancestor::*[self::af:breadCrumbs |
+																										   self::af:calendar |
+																										   self::af:carousel |
+                                                                                                           self::af:declarativeComponent |
+																										   self::af:iterator |
+																										   self::af:listView |
+																										   self::af:navigationPane | 
+																										   self::af:panelCollection | 
+																										   self::af:query | 
+																										   self::af:quickQuery | 
+																										   self::af:region | 
+																										   self::af:pageTemplate | 
+																										   self::af:subform | 
+																										   self::af:table | 
+																										   self::af:train |
+																										   self::af:trainButtonBar |
+                                                                                                           self::af:treeTable | 
+                                                                                                           self::af:tree |
+																										   self::af:subform |
+																										   self::dvt:schedulingGantt]" 				
+																						mode="collectAbsoluteId"/><xsl:value-of select="@id"/>";
+
+public <xsl:value-of select = "$vAdfComponentClassName"/> <xsl:text> </xsl:text> <xsl:value-of select = "$vAdfFindMethodName"/> () {
+	return findAdfComponent(<xsl:value-of select = "$vIdStringName" />);
+}
+   <xsl:choose>
+     <xsl:when test="name() = 'af:listView' or 
+					 name() = 'af:table' or
+					 name() = 'af:carousel' or
+					 name() = 'af:column'">
+		<!--For af:table, af:listView, af:carousel, in other words Direct Known Subclasses of ADFUIIterator Applying specific template which generates get-Methods-->
+		<!--Aslo for af:colums inside SchedulingGannt we apply specific template which generates get-Methods for the stamped inside columns components-->
+/*
+ * Methods to locate stamped-components
+*/
+		<xsl:apply-templates select = "node()" mode ="stampedComponents"/>
+     </xsl:when>
+     <xsl:otherwise>
+		<!--Applying general template which generate find-Methods-->
+       <xsl:apply-templates select = "node()"/>
+     </xsl:otherwise>
+   </xsl:choose>
+</xsl:template>
+
+<!--
+This template is used to generate part of Page Objects Model representing Adf Components stamped in the rows of af:table, af:listView, af:carousel, in other words Direct Known Subclasses of ADFUIIterator. See https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/toc.htm
+
+This is the specific template of one above.
+This one generates the statement for ComponentId of Adf Component only: final static String _id ="id-attribute value"
+The find-Method is not generated instead get-Methods are generated for id-string-properties.
+ -->
+
+<xsl:template mode ="stampedComponents" 
+			  match=   "af:button	|
+						af:commandButton	|
+						af:commandLink	|
+						af:commandMenuItem	|
+						af:commandNavigationItem	|
+						af:commandToolbarButton	|
+						af:inputComboboxListOfValues	|
+						af:inputDate	|
+						af:inputFile	|
+						af:inputListOfValues	|
+						af:inputNumberSpinbox	|
+						af:inputText	|
+						af:link	|
+						af:menu	|
+						af:outputFormatted	|
+						af:outputText	|
+						af:selectBooleanCheckbox	|
+						af:selectBooleanRadio	|
+						af:selectManyChoice	|
+						af:selectOneChoice	|
+						af:selectOneListbox	|
+						af:selectOneRadio	|
+						af:showDetailItem">
+
+<xsl:variable name="vAdfTagName" select="local-name()"/>
+<xsl:variable name="vAdfTagNameCamel" select="concat(translate(substring($vAdfTagName,1,1), $vLower, $vUpper), substring($vAdfTagName,2))"/>
+
+<xsl:variable name="vAdfElementName" >
+   <xsl:choose>
+     <xsl:when test="substring-before(substring-after(@value,'#{resourceObj.'),'}') != '' ">
+        <xsl:value-of select="substring-before(substring-after(@value,'#{resourceObj.'),'}')"/>
+     </xsl:when>
+     <xsl:otherwise>
+       <xsl:value-of select="concat('_',@id)"/>
+     </xsl:otherwise>
+   </xsl:choose>
+</xsl:variable> 
+
+<xsl:variable name="vAdfElementNameLow" select ="concat(translate(substring($vAdfElementName,1,1), $vUpper, $vLower), substring($vAdfElementName,2))"/>
+
+<xsl:variable name="vIdStringName" select ="concat($vAdfElementNameLow,$vAdfTagNameCamel,'Id')"/>
+static final String <xsl:value-of select = "$vIdStringName" /> = "<xsl:value-of select="@id"/>";
+public static final String get<xsl:value-of select = "$vIdStringName" />() {
+    return <xsl:value-of select = "$vIdStringName" />;
+}
+<xsl:apply-templates select = "node()" mode ="stampedComponents"/>
+</xsl:template>
+
+<!--This Template for collecting id-attribute values from selected ancestor's - naming container's of processed node-->
+<!--
+Note, that according to XSL specification <xsl:template match= /> could accept only child and attributes axes elements in pattern.
+That is why all needed naming container's should be selected in <xsl:apply-templates> statement and here in template itself match="*" is used.
+--> 
+<xsl:template 	match="*"				mode="collectAbsoluteId">
+	<xsl:value-of select="@id"/>
+	<xsl:text>:</xsl:text>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/xslt/inputListOfValues.jspx-to-Page-Objects.xsl
+++ b/xslt/inputListOfValues.jspx-to-Page-Objects.xsl
@@ -1,0 +1,229 @@
+<xsl:stylesheet version="1.0" 
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:jsp="http://java.sun.com/JSP/Page"
+	xmlns:af="http://xmlns.oracle.com/adf/faces/rich"
+	xmlns:f="http://java.sun.com/jsf/core"
+	xmlns:h="http://java.sun.com/jsf/html"
+	xmlns:trh="http://myfaces.apache.org/trinidad/html"
+    xmlns:c="http://java.sun.com/jsp/jstl/core" 
+	xmlns:dvt="http://xmlns.oracle.com/dss/adf/faces"
+    xmlns:wf="http://xmlns.oracle.com/bpel/workflow/workflow-taglib.tld"
+    xmlns:wlc="http://xmlns.oracle.com/bpel/workflow/worklist"
+	>
+	
+<xsl:output method="text"/>
+<xsl:strip-space elements="*" />
+
+<xsl:variable name="vLower" select="'abcdefghijklmnopqrstuvwxyz'"/>
+<xsl:variable name="vUpper" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'"/>
+
+<xsl:template match="/">
+/*
+ * XSLT Generated 
+ * This is Page Object Model for the tested ADF Page.
+ * The model includes java code for those of Adf Faces Tag which are listed xsl:template match=. You can change this list according to your needs and re-generate code for this class.
+ * Generated code includes: 
+ *	- String constant with ADF component AbsoluteId value. This constant then is used to locate component by corresponding findAdfComponent() method of SeleniumTools library.
+ *	- find-method which returm object instance representing ADF component.
+ * См.
+ * https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/oracle/adf/view/js/base/AdfPage.html#findComponentByAbsoluteId_String_
+ * https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/oracle/adf/view/js/component/AdfUIComponent.html#findComponent_String__Boolean_
+*/
+<!--
+Here set the component type starting processing from.
+For example, 
+1) set select = "//af:popup" in order to process child components of every popup not regarding to it hierarchy
+2) set select = "node()" in order to process from the top of document
+3) set select = "//af:table[@id='t8']" in order to process child components of particular table with id=t8
+  -->
+
+/*
+ * Methods to locate and interract with components in the section f:facet name="seriesComponent"
+*/  
+<xsl:apply-templates select = "//f:facet[@name='seriesComponent']"/>
+
+/*
+ * Methods to locate and interract with components in the section f:facet name="seriesBelow" -> af:panelFormLayout id="pfl1"
+*/  
+<xsl:apply-templates select = "//af:panelFormLayout[@id='pfl1']"/>
+
+
+</xsl:template>
+
+<!--
+This template is used to generate part of Page Objects Model representing Adf Components inside Naming Containers.
+
+This template generates 
+a) the statement for AbsoluteId of Adf Component only: final static String _id ="NC1id:NC2:ComponentId value"
+b) the statement for general implementation of find-Method. Implementation of find-Method bases on calling com.redheap.selenium.component.AdfComponent.findAdfComponent(_id).
+ -->
+
+<xsl:template match=   "af:button	|
+						af:column	|
+						af:commandButton	|
+						af:commandLink	|
+						af:commandMenuItem	|
+						af:commandNavigationItem	|
+						af:commandToolbarButton	|
+						af:dialog	|
+						af:inlineFrame	|
+						af:inputComboboxListOfValues	|
+						af:inputDate	|
+						af:inputFile	|
+						af:inputListOfValues	|
+						af:inputNumberSpinbox	|
+						af:inputText	|
+						af:link	|
+						af:listView |
+						af:menu	|
+						af:outputFormatted	|
+						af:outputText	|
+						af:popup	|
+						af:panelGridLayout |
+						af:selectBooleanCheckbox	|
+						af:selectBooleanRadio	|
+						af:selectManyChoice	|
+						af:selectOneChoice	|
+						af:selectOneListbox	|
+						af:selectOneRadio	|
+						af:showDetailItem |
+						af:table |
+						af:toolbar |
+						dvt:schedulingGantt |
+						dvt:timeAxis">
+
+<xsl:variable name="vAdfTagName" select="local-name()"/>
+<xsl:variable name="vAdfTagNameCamel" select="concat(translate(substring($vAdfTagName,1,1), $vLower, $vUpper), substring($vAdfTagName,2))"/>
+<xsl:variable name="vAdfComponentClassName" select="concat('Adf',$vAdfTagNameCamel)"/>
+
+<xsl:variable name="vAdfElementName" >
+   <xsl:choose>
+     <xsl:when test="@label">
+        <xsl:value-of select="@label"/>
+	 </xsl:when>
+     <xsl:when test="substring-before(substring-after(@value,'#{demoLOV.'),'}') != '' ">
+        <xsl:value-of select="substring-before(substring-after(@value,'#{demoLOV.'),'}')"/>
+     </xsl:when>
+     <xsl:otherwise>
+       <xsl:value-of select="concat('_',@id)"/>
+     </xsl:otherwise>
+   </xsl:choose>
+</xsl:variable> 
+
+<xsl:variable name="vAdfElementNameLow" select ="concat(translate(substring($vAdfElementName,1,1), $vUpper, $vLower), substring($vAdfElementName,2))"/>
+<xsl:variable name="vAdfElementNameUpper" select ="concat(translate(substring($vAdfElementName,1,1), $vLower, $vUpper), substring($vAdfElementName,2))"/>
+
+<xsl:variable name="vIdStringName" select ="concat($vAdfElementNameLow,$vAdfTagNameCamel)"/>
+<xsl:variable name="vAdfFindMethodName" select ="concat('find',$vAdfElementNameUpper)"/>
+static final String <xsl:value-of select = "$vIdStringName" /> = "<xsl:apply-templates 	select="ancestor::*[self::af:breadCrumbs |
+																										   self::af:calendar |
+																										   self::af:carousel |
+                                                                                                           self::af:declarativeComponent |
+																										   self::af:iterator |
+																										   self::af:listView |
+																										   self::af:navigationPane | 
+																										   self::af:panelCollection | 
+																										   self::af:query | 
+																										   self::af:quickQuery | 
+																										   self::af:region | 
+																										   self::af:pageTemplate | 
+																										   self::af:subform | 
+																										   self::af:table | 
+																										   self::af:train |
+																										   self::af:trainButtonBar |
+                                                                                                           self::af:treeTable | 
+                                                                                                           self::af:tree |
+																										   self::af:subform |
+																										   self::dvt:schedulingGantt]" 				
+																						mode="collectAbsoluteId"/><xsl:value-of select="@id"/>";
+
+public <xsl:value-of select = "$vAdfComponentClassName"/> <xsl:text> </xsl:text> <xsl:value-of select = "$vAdfFindMethodName"/> () {
+	return findAdfComponent(<xsl:value-of select = "$vIdStringName" />);
+}
+   <xsl:choose>
+     <xsl:when test="name() = 'af:listView' or 
+					 name() = 'af:table' or
+					 name() = 'af:carousel' or
+					 name() = 'af:column'">
+		<!--For af:table, af:listView, af:carousel, in other words Direct Known Subclasses of ADFUIIterator Applying specific template which generates get-Methods-->
+		<!--Aslo for af:colums inside SchedulingGannt we apply specific template which generates get-Methods for the stamped inside columns components-->
+/*
+ * Methods to locate stamped-components in the columns of SchedulingGantt
+*/
+		<xsl:apply-templates select = "node()" mode ="stampedComponents"/>
+     </xsl:when>
+     <xsl:otherwise>
+		<!--Applying general template which generate find-Methods-->
+       <xsl:apply-templates select = "node()"/>
+     </xsl:otherwise>
+   </xsl:choose>
+</xsl:template>
+
+<!--
+This template is used to generate part of Page Objects Model representing Adf Components stamped in the rows of af:table, af:listView, af:carousel, in other words Direct Known Subclasses of ADFUIIterator. See https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/toc.htm
+
+This is the specific template of one above.
+This one generates the statement for ComponentId of Adf Component only: final static String _id ="id-attribute value"
+The find-Method is not generated instead get-Methods are generated for id-string-properties.
+ -->
+
+<xsl:template mode ="stampedComponents" 
+			  match=   "af:button	|
+						af:commandButton	|
+						af:commandLink	|
+						af:commandMenuItem	|
+						af:commandNavigationItem	|
+						af:commandToolbarButton	|
+						af:inputComboboxListOfValues	|
+						af:inputDate	|
+						af:inputFile	|
+						af:inputListOfValues	|
+						af:inputNumberSpinbox	|
+						af:inputText	|
+						af:link	|
+						af:menu	|
+						af:outputFormatted	|
+						af:outputText	|
+						af:selectBooleanCheckbox	|
+						af:selectBooleanRadio	|
+						af:selectManyChoice	|
+						af:selectOneChoice	|
+						af:selectOneListbox	|
+						af:selectOneRadio	|
+						af:showDetailItem">
+
+<xsl:variable name="vAdfTagName" select="local-name()"/>
+<xsl:variable name="vAdfTagNameCamel" select="concat(translate(substring($vAdfTagName,1,1), $vLower, $vUpper), substring($vAdfTagName,2))"/>
+
+<xsl:variable name="vAdfElementName" >
+   <xsl:choose>
+     <xsl:when test="substring-before(substring-after(@value,'#{demoLOV.'),'}') != '' ">
+        <xsl:value-of select="substring-before(substring-after(@value,'#{demoLOV.'),'}')"/>
+     </xsl:when>
+     <xsl:otherwise>
+       <xsl:value-of select="concat('_',@id)"/>
+     </xsl:otherwise>
+   </xsl:choose>
+</xsl:variable> 
+
+<xsl:variable name="vAdfElementNameLow" select ="concat(translate(substring($vAdfElementName,1,1), $vUpper, $vLower), substring($vAdfElementName,2))"/>
+
+<xsl:variable name="vIdStringName" select ="concat($vAdfElementNameLow,$vAdfTagNameCamel,'Id')"/>
+static final String <xsl:value-of select = "$vIdStringName" /> = "<xsl:value-of select="@id"/>";
+public static final String get<xsl:value-of select = "$vIdStringName" />() {
+    return <xsl:value-of select = "$vIdStringName" />;
+}
+<xsl:apply-templates select = "node()" mode ="stampedComponents"/>
+</xsl:template>
+
+<!--This Template for collecting id-attribute values from selected ancestor's - naming container's of processed node-->
+<!--
+Note, that according to XSL specification <xsl:template match= /> could accept only child and attributes axes elements in pattern.
+That is why all needed naming container's should be selected in <xsl:apply-templates> statement and here in template itself match="*" is used.
+--> 
+<xsl:template 	match="*"				mode="collectAbsoluteId">
+	<xsl:value-of select="@id"/>
+	<xsl:text>:</xsl:text>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/xslt/jspx-jsff-with-dvt_to_Page-Objects_Transformation.xsl
+++ b/xslt/jspx-jsff-with-dvt_to_Page-Objects_Transformation.xsl
@@ -1,0 +1,299 @@
+<xsl:stylesheet version="1.0" 
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:jsp="http://java.sun.com/JSP/Page"
+	xmlns:af="http://xmlns.oracle.com/adf/faces/rich"
+	xmlns:f="http://java.sun.com/jsf/core"
+	xmlns:h="http://java.sun.com/jsf/html"
+	xmlns:trh="http://myfaces.apache.org/trinidad/html"
+    xmlns:c="http://java.sun.com/jsp/jstl/core" 
+	xmlns:dvt="http://xmlns.oracle.com/dss/adf/faces"
+    xmlns:wf="http://xmlns.oracle.com/bpel/workflow/workflow-taglib.tld"
+    xmlns:wlc="http://xmlns.oracle.com/bpel/workflow/worklist"
+	>
+	
+<xsl:output method="text"/>
+<xsl:strip-space elements="*" />
+
+<xsl:variable name="vLower" select="'abcdefghijklmnopqrstuvwxyz'"/>
+<xsl:variable name="vUpper" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'"/>
+
+<xsl:template match="/">
+/*
+ * XSLT Generated 
+ * Код моделирующий Page Object для Adf Faces Tag, которые предполагается использовать в автотестах. Список редактируется по мере необходимости в xsl:template match=
+ *	константа со значением AbsoluteId компонента, который используется для локации компонента на странице методом  findAdfComponent() библиотеки SeleniumTools
+ *	find-метод возвращающий экземпляр объекта на странице.
+ * См.
+ * https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/oracle/adf/view/js/base/AdfPage.html#findComponentByAbsoluteId_String_
+ * https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/oracle/adf/view/js/component/AdfUIComponent.html#findComponent_String__Boolean_
+*/
+<!--
+Here set the component type starting processing from.
+For example, 
+1) set select = "//af:popup" in order to process child components of every popup not regarding to it hierarchy
+2) set select = "node()" in order to process from the top of document
+3) set select = "//af:table[@id='t8']" in order to process child components of particular table with id=t8
+  -->
+
+/*
+ * /form | f:facet name="top"/
+ * Методы обращения к компонентам секции Приветствие 
+*/  
+<xsl:apply-templates select = "//af:panelGridLayout[@id='pgl24']"/>
+
+/*
+ * Методы обращения к компонентам popup Create Task
+*/  
+<xsl:apply-templates select = "//af:popup[@id='pPlanTask']"/>
+
+/*
+ * Методы обращения к компонентам popup Close Task
+*/  
+<xsl:apply-templates select = "//af:popup[@id='p3']"/>
+
+/*
+ * Методы обращения к компонентам popup Поиска клиента для отчета по ДЗ
+*/  
+<xsl:apply-templates select = "//af:popup[@id='p4']"/>
+
+/*
+ * Методы обращения к компонентам popup Upload File
+*/  
+<xsl:apply-templates select = "//af:popup[@id='p5']"/>
+
+/*
+ * Методы обращения к компонентам popup Transaction Add (Обещанный платеж)
+*/  
+<xsl:apply-templates select = "//af:popup[@id='p6']"/>
+
+/*
+ * Методы обращения к компонентам popup Ожидания загрузки
+*/  
+<xsl:apply-templates select = "//af:popup[@id='busyStatePopup']"/>
+
+/*
+ * /form | f:facet name="center" | panelSplitter | f:facet name="first" | af:panelAccordion id="pa1"/
+ * Методы обращения к компонентам секции аккордеона Фильтр подчиненных менеджеров
+*/  
+<xsl:apply-templates select = "//af:showDetailItem[@id='sdi1']"/>
+
+/*
+ * Методы обращения к компонентам секции аккордеона Фильтр задач
+*/  
+<xsl:apply-templates select = "//af:showDetailItem[@id='sdi2']"/>
+
+/*
+ * Методы обращения к компонентам секции аккордеона Меню отчетов по задачам
+*/  
+<xsl:apply-templates select = "//af:showDetailItem[@id='sdi3']"/>
+
+/*
+ * Методы обращения к компонентам секции аккордеона Меню отчетов по ДЗ
+*/  
+<xsl:apply-templates select = "//af:showDetailItem[@id='sdi4']"/>
+
+/*
+ * /form | f:facet name="center" | panelSplitter | f:facet name="second" | f:facet name="top" | f:facet name="start" /
+ * Методы обращения к компонентам секции Меню Ганта
+*/  
+<xsl:apply-templates select = "//af:panelGroupLayout[@id='pgl35']"/>
+
+/*
+ * /form | f:facet name="center" | panelSplitter | f:facet name="second" | f:facet name="top" | f:facet name="end" /
+ * Методы обращения к компонентам таблицы KPI
+*/  
+<xsl:apply-templates select = "//af:panelGridLayout[@id='pgl26']"/>
+
+/*
+ * /form | f:facet name="center" | panelSplitter | f:facet name="second" | f:facet name="center" | panelSplitter | f:facet name="first" /
+ * Методы обращения к компонентам диаграммы Ганта с задачами
+*/  
+<xsl:apply-templates select = "//dvt:schedulingGantt[@id='sg1']"/>
+
+/*
+ * /form | f:facet name="center" | panelSplitter | f:facet name="second" | f:facet name="center" | panelSplitter | f:facet name="second" /
+ * Методы обращения к компонентам секции Информация о клиенте
+*/  
+<xsl:apply-templates select = "//af:panelHeader[@id='ph1']"/>
+
+/*
+ * Методы обращения к компонентам секции Информация о задаче
+*/  
+<xsl:apply-templates select = "//af:panelHeader[@id='ph2']"/>
+
+</xsl:template>
+
+<!--
+This template is used to generate part of Page Objects Model representing Adf Components inside Naming Containers.
+
+This template generates 
+a) the statement for AbsoluteId of Adf Component only: final static String _id ="NC1id:NC2:ComponentId value"
+b) the statement for general implementation of find-Method. Implementation of find-Method bases on calling com.redheap.selenium.component.AdfComponent.findAdfComponent(_id).
+ -->
+
+<xsl:template match=   "af:button	|
+						af:column	|
+						af:commandButton	|
+						af:commandLink	|
+						af:commandMenuItem	|
+						af:commandNavigationItem	|
+						af:commandToolbarButton	|
+						af:dialog	|
+						af:inlineFrame	|
+						af:inputComboboxListOfValues	|
+						af:inputDate	|
+						af:inputFile	|
+						af:inputListOfValues	|
+						af:inputNumberSpinbox	|
+						af:inputText	|
+						af:link	|
+						af:listView |
+						af:menu	|
+						af:outputFormatted	|
+						af:outputText	|
+						af:popup	|
+						af:panelGridLayout |
+						af:selectBooleanCheckbox	|
+						af:selectBooleanRadio	|
+						af:selectManyChoice	|
+						af:selectOneChoice	|
+						af:selectOneListbox	|
+						af:selectOneRadio	|
+						af:showDetailItem |
+						af:table |
+						af:toolbar |
+						dvt:schedulingGantt |
+						dvt:timeAxis">
+
+<xsl:variable name="vAdfTagName" select="local-name()"/>
+<xsl:variable name="vAdfTagNameCamel" select="concat(translate(substring($vAdfTagName,1,1), $vLower, $vUpper), substring($vAdfTagName,2))"/>
+<xsl:variable name="vAdfComponentClassName" select="concat('Adf',$vAdfTagNameCamel)"/>
+
+<xsl:variable name="vAdfElementName" >
+   <xsl:choose>
+     <xsl:when test="substring-before(substring-after(@value,'#{bindings.'),'.') != '' ">
+        <xsl:value-of select="substring-before(substring-after(@value,'#{bindings.'),'.')"/>
+     </xsl:when>
+     <xsl:otherwise>
+       <xsl:value-of select="concat('_',@id)"/>
+     </xsl:otherwise>
+   </xsl:choose>
+</xsl:variable> 
+
+<xsl:variable name="vAdfElementNameLow" select ="concat(translate(substring($vAdfElementName,1,1), $vUpper, $vLower), substring($vAdfElementName,2))"/>
+<xsl:variable name="vAdfElementNameUpper" select ="concat(translate(substring($vAdfElementName,1,1), $vLower, $vUpper), substring($vAdfElementName,2))"/>
+
+<xsl:variable name="vIdStringName" select ="concat($vAdfElementNameLow,$vAdfTagNameCamel)"/>
+<xsl:variable name="vAdfFindMethodName" select ="concat('find',$vAdfElementNameUpper)"/>
+static final String <xsl:value-of select = "$vIdStringName" /> = "<xsl:apply-templates 	select="ancestor::*[self::af:breadCrumbs |
+																										   self::af:calendar |
+																										   self::af:carousel |
+                                                                                                           self::af:declarativeComponent |
+																										   self::af:iterator |
+																										   self::af:listView |
+																										   self::af:navigationPane | 
+																										   self::af:panelCollection | 
+																										   self::af:query | 
+																										   self::af:quickQuery | 
+																										   self::af:region | 
+																										   self::af:pageTemplate | 
+																										   self::af:subform | 
+																										   self::af:table | 
+																										   self::af:train |
+																										   self::af:trainButtonBar |
+                                                                                                           self::af:treeTable | 
+                                                                                                           self::af:tree |
+																										   self::af:subform |
+																										   self::dvt:schedulingGantt]" 				
+																						mode="collectAbsoluteId"/><xsl:value-of select="@id"/>";
+
+public <xsl:value-of select = "$vAdfComponentClassName"/> <xsl:text> </xsl:text> <xsl:value-of select = "$vAdfFindMethodName"/> () {
+	return findAdfComponent(<xsl:value-of select = "$vIdStringName" />);
+}
+   <xsl:choose>
+     <xsl:when test="name() = 'af:listView' or 
+					 name() = 'af:table' or
+					 name() = 'af:carousel' or
+					 name() = 'af:column'">
+		<!--For af:table, af:listView, af:carousel, in other words Direct Known Subclasses of ADFUIIterator Applying specific template which generates get-Methods-->
+		<!--Aslo for af:colums inside SchedulingGannt we apply specific template which generates get-Methods for the stamped inside columns components-->
+/*
+ * Методы для локации stamped-компонентов в колонках SchedulingGantt
+*/
+		<xsl:apply-templates select = "node()" mode ="stampedComponents"/>
+     </xsl:when>
+     <xsl:otherwise>
+		<!--Applying general template which generate find-Methods-->
+       <xsl:apply-templates select = "node()"/>
+     </xsl:otherwise>
+   </xsl:choose>
+</xsl:template>
+
+<!--
+This template is used to generate part of Page Objects Model representing Adf Components stamped in the rows of af:table, af:listView, af:carousel, in other words Direct Known Subclasses of ADFUIIterator. See https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/toc.htm
+
+This is the specific template of one above.
+This one generates the statement for ComponentId of Adf Component only: final static String _id ="id-attribute value"
+The find-Method is not generated instead get-Methods are generated for id-string-properties.
+ -->
+
+<xsl:template mode ="stampedComponents" 
+			  match=   "af:button	|
+						af:commandButton	|
+						af:commandLink	|
+						af:commandMenuItem	|
+						af:commandNavigationItem	|
+						af:commandToolbarButton	|
+						af:inputComboboxListOfValues	|
+						af:inputDate	|
+						af:inputFile	|
+						af:inputListOfValues	|
+						af:inputNumberSpinbox	|
+						af:inputText	|
+						af:link	|
+						af:menu	|
+						af:outputFormatted	|
+						af:outputText	|
+						af:selectBooleanCheckbox	|
+						af:selectBooleanRadio	|
+						af:selectManyChoice	|
+						af:selectOneChoice	|
+						af:selectOneListbox	|
+						af:selectOneRadio	|
+						af:showDetailItem">
+
+<xsl:variable name="vAdfTagName" select="local-name()"/>
+<xsl:variable name="vAdfTagNameCamel" select="concat(translate(substring($vAdfTagName,1,1), $vLower, $vUpper), substring($vAdfTagName,2))"/>
+
+<xsl:variable name="vAdfElementName" >
+   <xsl:choose>
+     <xsl:when test="substring-before(substring-after(@value,'#{bindings.'),'.') != '' ">
+        <xsl:value-of select="substring-before(substring-after(@value,'#{bindings.'),'.')"/>
+     </xsl:when>
+     <xsl:otherwise>
+       <xsl:value-of select="concat('_',@id)"/>
+     </xsl:otherwise>
+   </xsl:choose>
+</xsl:variable> 
+
+<xsl:variable name="vAdfElementNameLow" select ="concat(translate(substring($vAdfElementName,1,1), $vUpper, $vLower), substring($vAdfElementName,2))"/>
+
+<xsl:variable name="vIdStringName" select ="concat($vAdfElementNameLow,$vAdfTagNameCamel,'Id')"/>
+static final String <xsl:value-of select = "$vIdStringName" /> = "<xsl:value-of select="@id"/>";
+public static final String get<xsl:value-of select = "$vIdStringName" />() {
+    return <xsl:value-of select = "$vIdStringName" />;
+}
+<xsl:apply-templates select = "node()" mode ="stampedComponents"/>
+</xsl:template>
+
+<!--This Template for collecting id-attribute values from selected ancestor's - naming container's of processed node-->
+<!--
+Note, that according to XSL specification <xsl:template match= /> could accept only child and attributes axes elements in pattern.
+That is why all needed naming container's should be selected in <xsl:apply-templates> statement and here in template itself match="*" is used.
+--> 
+<xsl:template 	match="*"				mode="collectAbsoluteId">
+	<xsl:value-of select="@id"/>
+	<xsl:text>:</xsl:text>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/xslt/jspx-jsff_to_Page-Objects_Transformation.xsl
+++ b/xslt/jspx-jsff_to_Page-Objects_Transformation.xsl
@@ -1,0 +1,279 @@
+<xsl:stylesheet version="1.0" 
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:f="http://java.sun.com/jsf/core"
+	xmlns:af="http://xmlns.oracle.com/adf/faces/rich"
+	xmlns:afh="http://myfaces.apache.org/trinidad/html"
+	xmlns:wlc="http://xmlns.oracle.com/bpel/workflow/worklist"
+	xmlns:c="http://java.sun.com/jsp/jstl/core">
+	
+<xsl:output method="text"/>
+<xsl:strip-space elements="*" />
+
+<xsl:variable name="vLower" select="'abcdefghijklmnopqrstuvwxyz'"/>
+<xsl:variable name="vUpper" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'"/>
+
+<xsl:template match="/">
+/*
+ * XSLT Generated 
+ * Код моделирующий Page Object для Adf Faces Tag, которые предполагается использовать в автотестах. Список редактируется по мере необходимости в xsl:template match=
+ *	константа со значением AbsoluteId компонента, который используется для локации компонента на странице методом  findAdfComponent() библиотеки SeleniumTools
+ *	find-метод возвращающий экземпляр объекта на странице.
+ * См.
+ * https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/oracle/adf/view/js/base/AdfPage.html#findComponentByAbsoluteId_String_
+ * https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/oracle/adf/view/js/component/AdfUIComponent.html#findComponent_String__Boolean_
+*/
+<!--
+Here set the component type starting processing from.
+For example, 
+1) set select = "//af:popup" in order to process child components of every popup not regarding to it hierarchy
+2) set select = "node()" in order to process from the top of document
+3) set select = "//af:table[@id='t8']" in order to process child components of particular table with id=t8
+  -->
+/*
+ * Метод для локации региона из центральной секции страницы f:facet name="center"
+*/
+<xsl:apply-templates select = "//af:region[@id='r1']"/>
+  
+/*
+ * Методы для локации объектов верхней секции страницы f:facet name="top"
+*/
+<xsl:apply-templates select = "//af:panelGridLayout[@id='pgl1']"/>
+
+/*
+ * Методы для локации объектов размещенных в нижней секции страницы f:facet name="bottom"
+*/
+<xsl:apply-templates select = "//af:panelGroupLayout[@id='pgl3']"/>
+
+</xsl:template>
+
+<!--
+This template is used to generate part of Page Objects Model representing Adf Components inside Naming Containers.
+
+This template generates 
+a) the statement for AbsoluteId of Adf Component only: final static String _id ="NC1id:NC2:ComponentId value"
+b) the statement for general implementation of find-Method. Implementation of find-Method bases on calling com.redheap.selenium.component.AdfComponent.findAdfComponent(_id).
+ -->
+  <xsl:template match="af:button	|
+                        af:column	|
+                        af:commandButton	|
+                        af:commandLink	|
+                        af:commandMenuItem	|
+                        af:commandNavigationItem	|
+                        af:commandToolbarButton	|
+                        af:dialog	|
+                        af:inlineFrame	|
+                        af:inputComboboxListOfValues	|
+                        af:inputDate	|
+                        af:inputFile	|
+                        af:inputListOfValues	|
+                        af:inputNumberSpinbox	|
+                        af:inputText	|
+                        af:link	|
+                        af:listView |
+                        af:menu	|
+                        af:outputFormatted	|
+                        af:outputText	|
+                        af:popup	|
+						af:panelWindow |
+						af:query |
+						af:region |
+                        af:selectBooleanCheckbox	|
+                        af:selectBooleanRadio	|
+                        af:selectManyChoice	|
+                        af:selectOneChoice	|
+                        af:selectOneListbox	|
+                        af:selectOneRadio	|
+                        af:showDetailItem |
+						af:table">
+
+<xsl:variable name="vAdfTagName" select="local-name()"/>
+<xsl:variable name="vAdfTagNameCamel"
+              select="concat(translate(substring($vAdfTagName,1,1), $vLower, $vUpper), substring($vAdfTagName,2))"/>
+<xsl:variable name="vAdfComponentClassName" select="concat('Adf',$vAdfTagNameCamel)"/>
+
+<!--Try extract form #{bindings string text for the element name to use later in method's name -->
+<xsl:variable name="vAdfElementName">
+   <xsl:choose>
+        <xsl:when test="substring-before(substring-after(@value,'#{bindings.'),'.') != '' ">
+        <xsl:value-of select="substring-before(substring-after(@value,'#{bindings.'),'.')"/>
+     </xsl:when>
+        <xsl:otherwise>
+       <xsl:value-of select="concat('_',@id)"/>
+     </xsl:otherwise>
+      </xsl:choose>
+</xsl:variable> 
+
+<xsl:variable name="vAdfElementNameLow"
+              select="concat(translate(substring($vAdfElementName,1,1), $vUpper, $vLower), substring($vAdfElementName,2))"/>
+<xsl:variable name="vAdfElementNameUpper"
+              select="concat(translate(substring($vAdfElementName,1,1), $vLower, $vUpper), substring($vAdfElementName,2))"/>
+
+<!--If processed node has ancestor-popup then use popup's id as part of java variables and methods name to make it unique   -->
+<xsl:variable name="vParentPopupId">
+   <xsl:choose>
+        <xsl:when test="ancestor::af:popup">
+        <xsl:value-of select="concat('_On_',ancestor::af:popup[1]/@id)"/>
+     </xsl:when>
+        <xsl:otherwise>
+       <xsl:value-of select="''"/>
+     </xsl:otherwise>
+      </xsl:choose>
+</xsl:variable> 
+
+<xsl:variable name="vIdStringName" select="concat($vAdfElementNameLow,$vAdfTagNameCamel,$vParentPopupId)"/>
+<xsl:variable name="vAdfFindMethodName" select="concat('find',$vAdfElementNameUpper,$vParentPopupId)"/>
+<xsl:variable name="vAbsoluteId">
+	<xsl:apply-templates select="ancestor::*[self::af:breadCrumbs |
+											 self::af:calendar |
+											 self::af:carousel |
+											 self::af:declarativeComponent |
+											 self::af:iterator |
+											 self::af:listView |
+											 self::af:navigationPane | 
+											 self::af:panelCollection | 
+											 self::af:query | 
+											 self::af:quickQuery | 
+											 self::af:region | 
+											 self::af:pageTemplate | 
+											 self::af:subform | 
+											 self::af:table | 
+											 self::af:train |
+											 self::af:trainButtonBar |
+											 self::af:treeTable | 
+											 self::af:tree |
+											 self::af:subform]"
+						 mode="collectAbsoluteId"/><xsl:value-of select="@id"/>
+</xsl:variable>
+
+<!--If processed node is popup then try extract text for the comment about that popup form @title or @binding of any child of popup   -->
+<xsl:choose>
+ <xsl:when test="name() = 'af:popup'">
+/*
+ * Методы для локации объектов popup '<xsl:choose>
+										<xsl:when test="descendant::*[@title]">
+											<xsl:value-of select="*[@title]/@title"/>'
+										</xsl:when>
+										<xsl:when test="descendant::*[@text]">
+											<xsl:value-of select="descendant::*[@text][1]/@text"/>'
+										</xsl:when>
+										<xsl:otherwise>
+											<xsl:value-of select="*[@binding]/@binding"/>'
+										</xsl:otherwise>
+									  </xsl:choose>
+*/
+ </xsl:when>
+</xsl:choose>
+static final String <xsl:value-of select="$vIdStringName"/> = "<xsl:value-of select="$vAbsoluteId"/>";
+
+public <xsl:value-of select="$vAdfComponentClassName"/> <xsl:text> </xsl:text> <xsl:value-of select="$vAdfFindMethodName"/> () {
+	return findAdfComponent(<xsl:value-of select="$vIdStringName"/>);
+}
+	<xsl:choose>
+		<!--Special transforming for af:region and other ADF Faces tags that locate Fragments -->
+		<xsl:when test="name() = 'af:region'">
+public 'Insert here appropriate fragment's class name' get<xsl:value-of select="$vIdStringName"/>Content () {
+    //Add here code for fragment's initialization action on you page. Like: findOrderListTab().click();
+    return new 'Insert here call of appropriate fragment constructor'(<xsl:value-of select="$vAdfFindMethodName"/>());
+}
+		</xsl:when>
+		<!--Then transforming for all others ADF Faces tags-->
+		<xsl:otherwise>
+			<xsl:choose>
+				<!--Special transforming for af:table, af:listView, af:carousel -->
+				<xsl:when test="name() = 'af:listView' or 
+								name() = 'af:table' or
+								name() = 'af:carousel'">
+				<!--For all non-column-childes of af:table, af:listView, af:carousel, in other words Direct Known Subclasses of ADFUIIterator applying specific template which generates get-Methods-->
+/*
+ * Метод для локации stamped-объектов таблицы
+*/
+				<xsl:apply-templates select="node()" mode="stampedComponents"/>
+				<!--For all column-childes of af:table, af:listView, af:carousel, applying general template which generates and generate find-Methods. And see the next comment below -->
+/*
+ * Метод для локации объектов колонок таблицы
+*/
+				<xsl:apply-templates select="af:column"/>
+				</xsl:when>
+				<!--For childes of columns do nothing, because childes of columns are actually childes of af:table, af:listView, af:carousel-->
+				<xsl:when test="name() = 'af:column'">
+				<!--Do nothing here and stop processing the on the column itself-->
+				</xsl:when>
+				<!--Then transforming for the rest of ADF Faces tags-->
+				<xsl:otherwise>
+				<!--Applying general template which generate find-Methods-->
+					<xsl:apply-templates select="node()"/>
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:otherwise>
+	</xsl:choose>
+</xsl:template>
+
+<!--
+This template is used to generate part of Page Objects Model representing Adf Components stamped in the rows of af:table, af:listView, af:carousel, in other words Direct Known Subclasses of ADFUIIterator. See https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/toc.htm
+This is the specific template of one above.
+This one generates the statement for ComponentId of Adf Component only: final static String _id ="id-attribute value"
+The find-Method is not generated instead get-Methods are generated for id-string-properties.
+Note: <af:column> is not stamped inside the table, so usually it should not be included in match attribute below.
+	  But for taskTable we need work with table as WebElement and will use for columns also ComponentId's and get-Methods.
+ -->
+<xsl:template mode ="stampedComponents" 
+			  match=   "af:button	|
+
+                                    af:commandButton	|
+                                    af:commandLink	|
+                                    af:commandMenuItem	|
+                                    af:commandNavigationItem	|
+                                    af:commandToolbarButton	|
+                                    af:inputComboboxListOfValues	|
+                                    af:inputDate	|
+                                    af:inputFile	|
+                                    af:inputListOfValues	|
+                                    af:inputNumberSpinbox	|
+                                    af:inputText	|
+                                    af:link	|
+                                    af:menu	|
+                                    af:outputFormatted	|
+                                    af:outputText	|
+                                    af:selectBooleanCheckbox	|
+                                    af:selectBooleanRadio	|
+                                    af:selectManyChoice	|
+                                    af:selectOneChoice	|
+                                    af:selectOneListbox	|
+                                    af:selectOneRadio	|
+                                    af:showDetailItem">
+
+<xsl:variable name="vAdfTagName" select="local-name()"/>
+<xsl:variable name="vAdfTagNameCamel" select="concat(translate(substring($vAdfTagName,1,1), $vLower, $vUpper), substring($vAdfTagName,2))"/>
+
+<xsl:variable name="vAdfElementName" >
+   <xsl:choose>
+     <xsl:when test="substring-before(substring-after(@value,'#{bindings.'),'.') != '' ">
+        <xsl:value-of select="substring-before(substring-after(@value,'#{bindings.'),'.')"/>
+     </xsl:when>
+     <xsl:otherwise>
+       <xsl:value-of select="concat('_',@id)"/>
+     </xsl:otherwise>
+   </xsl:choose>
+</xsl:variable> 
+
+<xsl:variable name="vAdfElementNameLow" select ="concat(translate(substring($vAdfElementName,1,1), $vUpper, $vLower), substring($vAdfElementName,2))"/>
+
+<xsl:variable name="vIdStringName" select ="concat($vAdfElementNameLow,$vAdfTagNameCamel,'Id')"/>
+static final String <xsl:value-of select = "$vIdStringName" /> = "<xsl:value-of select="@id"/>";
+public static final String get<xsl:value-of select = "$vIdStringName" />() {
+    return <xsl:value-of select = "$vIdStringName" />;
+}
+<xsl:apply-templates select = "node()" mode ="stampedComponents"/>
+</xsl:template>
+
+<!--This Template for collecting id-attribute values from selected ancestor's - naming container's of processed node-->
+<!--
+Note, that according to XSL specification <xsl:template match= /> could accept only child and attributes axes elements in pattern.
+That is why all needed naming container's should be selected in <xsl:apply-templates> statement and here in template itself match="*" is used.
+--> 
+<xsl:template 	match="*"   mode="collectAbsoluteId">
+	<xsl:value-of select="@id"/>
+	<xsl:text>:</xsl:text>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/xslt/schedulingGantt.jspx-to-Page-Objects.xsl
+++ b/xslt/schedulingGantt.jspx-to-Page-Objects.xsl
@@ -1,0 +1,222 @@
+<xsl:stylesheet version="1.0" 
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:jsp="http://java.sun.com/JSP/Page"
+	xmlns:af="http://xmlns.oracle.com/adf/faces/rich"
+	xmlns:f="http://java.sun.com/jsf/core"
+	xmlns:h="http://java.sun.com/jsf/html"
+	xmlns:trh="http://myfaces.apache.org/trinidad/html"
+    xmlns:c="http://java.sun.com/jsp/jstl/core" 
+	xmlns:dvt="http://xmlns.oracle.com/dss/adf/faces"
+    xmlns:wf="http://xmlns.oracle.com/bpel/workflow/workflow-taglib.tld"
+    xmlns:wlc="http://xmlns.oracle.com/bpel/workflow/worklist"
+	>
+	
+<xsl:output method="text"/>
+<xsl:strip-space elements="*" />
+
+<xsl:variable name="vLower" select="'abcdefghijklmnopqrstuvwxyz'"/>
+<xsl:variable name="vUpper" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'"/>
+
+<xsl:template match="/">
+/*
+ * XSLT Generated 
+ * This is Page Object Model for the tested ADF Page.
+ * The model includes java code for those of Adf Faces Tag which are listed xsl:template match=. You can change this list according to your needs and re-generate code for this class.
+ * Generated code includes: 
+ *	- String constant with ADF component AbsoluteId value. This constant then is used to locate component by corresponding findAdfComponent() method of SeleniumTools library.
+ *	- find-method which returm object instance representing ADF component.
+ * См.
+ * https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/oracle/adf/view/js/base/AdfPage.html#findComponentByAbsoluteId_String_
+ * https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/oracle/adf/view/js/component/AdfUIComponent.html#findComponent_String__Boolean_
+*/
+<!--
+Here set the component type starting processing from.
+For example, 
+1) set select = "//af:popup" in order to process child components of every popup not regarding to it hierarchy
+2) set select = "node()" in order to process from the top of document
+3) set select = "//af:table[@id='t8']" in order to process child components of particular table with id=t8
+  -->
+
+/*
+ * !-- START TAG DEMO -->
+ * Methods to locate and interract with dvt:schedulingGantt demo component
+*/  
+<xsl:apply-templates select = "//dvt:schedulingGantt[@id='schedulingGant']"/>
+
+
+</xsl:template>
+
+<!--
+This template is used to generate part of Page Objects Model representing Adf Components inside Naming Containers.
+
+This template generates 
+a) the statement for AbsoluteId of Adf Component only: final static String _id ="NC1id:NC2:ComponentId value"
+b) the statement for general implementation of find-Method. Implementation of find-Method bases on calling com.redheap.selenium.component.AdfComponent.findAdfComponent(_id).
+ -->
+
+<xsl:template match=   "af:button	|
+						af:column	|
+						af:commandButton	|
+						af:commandLink	|
+						af:commandMenuItem	|
+						af:commandNavigationItem	|
+						af:commandToolbarButton	|
+						af:dialog	|
+						af:inlineFrame	|
+						af:inputComboboxListOfValues	|
+						af:inputDate	|
+						af:inputFile	|
+						af:inputListOfValues	|
+						af:inputNumberSpinbox	|
+						af:inputText	|
+						af:link	|
+						af:listView |
+						af:menu	|
+						af:outputFormatted	|
+						af:outputText	|
+						af:popup	|
+						af:panelGridLayout |
+						af:selectBooleanCheckbox	|
+						af:selectBooleanRadio	|
+						af:selectManyChoice	|
+						af:selectOneChoice	|
+						af:selectOneListbox	|
+						af:selectOneRadio	|
+						af:showDetailItem |
+						af:table |
+						af:toolbar |
+						dvt:schedulingGantt |
+						dvt:timeAxis">
+
+<xsl:variable name="vAdfTagName" select="local-name()"/>
+<xsl:variable name="vAdfTagNameCamel" select="concat(translate(substring($vAdfTagName,1,1), $vLower, $vUpper), substring($vAdfTagName,2))"/>
+<xsl:variable name="vAdfComponentClassName" select="concat('Adf',$vAdfTagNameCamel)"/>
+
+<xsl:variable name="vAdfElementName" >
+   <xsl:choose>
+     <xsl:when test="substring-before(substring-after(@value,'#{bindings.'),'.') != '' ">
+        <xsl:value-of select="substring-before(substring-after(@value,'#{bindings.'),'.')"/>
+     </xsl:when>
+     <xsl:otherwise>
+       <xsl:value-of select="concat('_',@id)"/>
+     </xsl:otherwise>
+   </xsl:choose>
+</xsl:variable> 
+
+<xsl:variable name="vAdfElementNameLow" select ="concat(translate(substring($vAdfElementName,1,1), $vUpper, $vLower), substring($vAdfElementName,2))"/>
+<xsl:variable name="vAdfElementNameUpper" select ="concat(translate(substring($vAdfElementName,1,1), $vLower, $vUpper), substring($vAdfElementName,2))"/>
+
+<xsl:variable name="vIdStringName" select ="concat($vAdfElementNameLow,$vAdfTagNameCamel)"/>
+<xsl:variable name="vAdfFindMethodName" select ="concat('find',$vAdfElementNameUpper)"/>
+static final String <xsl:value-of select = "$vIdStringName" /> = "<xsl:apply-templates 	select="ancestor::*[self::af:breadCrumbs |
+																										   self::af:calendar |
+																										   self::af:carousel |
+                                                                                                           self::af:declarativeComponent |
+																										   self::af:iterator |
+																										   self::af:listView |
+																										   self::af:navigationPane | 
+																										   self::af:panelCollection | 
+																										   self::af:query | 
+																										   self::af:quickQuery | 
+																										   self::af:region | 
+																										   self::af:pageTemplate | 
+																										   self::af:subform | 
+																										   self::af:table | 
+																										   self::af:train |
+																										   self::af:trainButtonBar |
+                                                                                                           self::af:treeTable | 
+                                                                                                           self::af:tree |
+																										   self::af:subform |
+																										   self::dvt:schedulingGantt]" 				
+																						mode="collectAbsoluteId"/><xsl:value-of select="@id"/>";
+
+public <xsl:value-of select = "$vAdfComponentClassName"/> <xsl:text> </xsl:text> <xsl:value-of select = "$vAdfFindMethodName"/> () {
+	return findAdfComponent(<xsl:value-of select = "$vIdStringName" />);
+}
+   <xsl:choose>
+     <xsl:when test="name() = 'af:listView' or 
+					 name() = 'af:table' or
+					 name() = 'af:carousel' or
+					 name() = 'af:column'">
+		<!--For af:table, af:listView, af:carousel, in other words Direct Known Subclasses of ADFUIIterator Applying specific template which generates get-Methods-->
+		<!--Aslo for af:colums inside SchedulingGannt we apply specific template which generates get-Methods for the stamped inside columns components-->
+/*
+ * Methods to locate stamped-components in the columns of SchedulingGantt
+*/
+		<xsl:apply-templates select = "node()" mode ="stampedComponents"/>
+     </xsl:when>
+     <xsl:otherwise>
+		<!--Applying general template which generate find-Methods-->
+       <xsl:apply-templates select = "node()"/>
+     </xsl:otherwise>
+   </xsl:choose>
+</xsl:template>
+
+<!--
+This template is used to generate part of Page Objects Model representing Adf Components stamped in the rows of af:table, af:listView, af:carousel, in other words Direct Known Subclasses of ADFUIIterator. See https://docs.oracle.com/middleware/12213/adf/api-reference-javascript-faces/toc.htm
+
+This is the specific template of one above.
+This one generates the statement for ComponentId of Adf Component only: final static String _id ="id-attribute value"
+The find-Method is not generated instead get-Methods are generated for id-string-properties.
+ -->
+
+<xsl:template mode ="stampedComponents" 
+			  match=   "af:button	|
+						af:commandButton	|
+						af:commandLink	|
+						af:commandMenuItem	|
+						af:commandNavigationItem	|
+						af:commandToolbarButton	|
+						af:inputComboboxListOfValues	|
+						af:inputDate	|
+						af:inputFile	|
+						af:inputListOfValues	|
+						af:inputNumberSpinbox	|
+						af:inputText	|
+						af:link	|
+						af:menu	|
+						af:outputFormatted	|
+						af:outputText	|
+						af:selectBooleanCheckbox	|
+						af:selectBooleanRadio	|
+						af:selectManyChoice	|
+						af:selectOneChoice	|
+						af:selectOneListbox	|
+						af:selectOneRadio	|
+						af:showDetailItem">
+
+<xsl:variable name="vAdfTagName" select="local-name()"/>
+<xsl:variable name="vAdfTagNameCamel" select="concat(translate(substring($vAdfTagName,1,1), $vLower, $vUpper), substring($vAdfTagName,2))"/>
+
+<xsl:variable name="vAdfElementName" >
+   <xsl:choose>
+     <xsl:when test="substring-before(substring-after(@value,'#{resourceObj.'),'}') != '' ">
+        <xsl:value-of select="substring-before(substring-after(@value,'#{resourceObj.'),'}')"/>
+     </xsl:when>
+     <xsl:otherwise>
+       <xsl:value-of select="concat('_',@id)"/>
+     </xsl:otherwise>
+   </xsl:choose>
+</xsl:variable> 
+
+<xsl:variable name="vAdfElementNameLow" select ="concat(translate(substring($vAdfElementName,1,1), $vUpper, $vLower), substring($vAdfElementName,2))"/>
+
+<xsl:variable name="vIdStringName" select ="concat($vAdfElementNameLow,$vAdfTagNameCamel,'Id')"/>
+static final String <xsl:value-of select = "$vIdStringName" /> = "<xsl:value-of select="@id"/>";
+public static final String get<xsl:value-of select = "$vIdStringName" />() {
+    return <xsl:value-of select = "$vIdStringName" />;
+}
+<xsl:apply-templates select = "node()" mode ="stampedComponents"/>
+</xsl:template>
+
+<!--This Template for collecting id-attribute values from selected ancestor's - naming container's of processed node-->
+<!--
+Note, that according to XSL specification <xsl:template match= /> could accept only child and attributes axes elements in pattern.
+That is why all needed naming container's should be selected in <xsl:apply-templates> statement and here in template itself match="*" is used.
+--> 
+<xsl:template 	match="*"				mode="collectAbsoluteId">
+	<xsl:value-of select="@id"/>
+	<xsl:text>:</xsl:text>
+</xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
Hi, Richard @RichardOlrichs, Wilfred @wvanderdeijl
After a project where I used SeleniumTools I have collected all updates and  pleased to contribute them.

The main thing here is added support for Selenium-3.3.1+. So it includes Fixes #23.
Also very useful xslt has added which allow generate Page Object class for any jspx, jsff.

As well 
1. some missing ADF components has been added into SeleniumTools
2. fixes and extensions have been made for existed components
3. support for DVT component has been added
3. some examples with page models and test into RichClientDemoTest project

Please review and aprove this pull request. I'm not sure, because it is my first pull request to github, maybe it is better to merge my branch as a separate one and not into Jdev12.2-Java8.
 
Let me know if you need some clarification.
